### PR TITLE
Pass the whole OAuth client

### DIFF
--- a/lib/authorise.js
+++ b/lib/authorise.js
@@ -92,7 +92,7 @@ function getUserFromClient(done) {
         return done(error('invalid_grant', 'Client credentials are invalid'));
       }
 
-      self.req.oauth = { bearerToken: user, client: self.client };
+      self.req.oauth = { bearerToken: user, client };
       self.req.user = { id: user.id };
 
       done();


### PR DESCRIPTION
Currently, the OAuth server propagates only the client ID and secret in `req.oauth` and are missing important info like the client's org/product ID or the scopes. This change will allow passing all the info we have about the client back into the request.