### PR TITLE
do object recognition on original objects

### DIFF
--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -237,7 +237,8 @@ OAuth2Server.prototype.lockdown = function (app) {
 
   var lockdownExpress4 = function (layer) {
     if (layer.name === 'router') {
-      layer.handle.stack.forEach(lockdownExpress4);
+      const handle = layer.handle._datadog_orig || layer.handle;
+      handle.stack.forEach(lockdownExpress4);
       return;
     }
 

--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -246,7 +246,7 @@ OAuth2Server.prototype.lockdown = function (app) {
 
     var stack = layer.route.stack;
     var handlers = stack.map(function (item) {
-      return item.handle;
+      return item.handle._datadog_orig || item.handle;
     });
 
     // Check if it's a grant route


### PR DESCRIPTION
As part of ch70998 we need to let OAuth2Server match objects on the original versions.

We would like to disable the automated wrapping elsewhere, but we were not able to find the right settings to do this