### PR TITLE
feature/sc-117375/don-t-allow-password-login-for-a-user-with

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -189,6 +189,11 @@ Note: see https://github.com/thomseddon/node-oauth2-server/tree/master/examples/
 
 ### Required for `password` grant type
 
+#### checkSSOUser (username, req)
+- *string* **username**
+- *object* **req**
+ - The current express request
+
 #### getUser (username, password, callback)
 - *string* **username**
 - *string* **password**
@@ -314,6 +319,7 @@ grant_type=password&username=johndoe&password=A3ddj3w&scope=readonly
 This will then call the following on your model (in this order):
  - getClient (clientId, clientSecret, callback)
  - grantTypeAllowed (clientId, grantType, callback)
+ - checkSSOUser (username)
  - getUser (username, password, callback)
  - saveAccessToken (accessToken, clientId, expires, user, scope, callback)
  - saveRefreshToken (refreshToken, clientId, expires, user, callback) **(if using)**

--- a/lib/error.js
+++ b/lib/error.js
@@ -60,6 +60,9 @@ function OAuth2Error (error, description, err) {
     case 'invalid_token':
       this.code = 401;
       break;
+    case 'sso_user':
+      this.code = 403;
+      break;
     case 'mfa_required':
       this.code = 403;
       this.mfa_token = description;

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -206,17 +206,22 @@ function usePasswordGrant (done) {
   }
 
   var self = this;
-  return this.model.getUser(uname, pword, function (err, user) {
-    if (err) return done(error('server_error', false, err));
-    if (!user) {
-      return done(error('invalid_grant', 'User credentials are invalid'));
-    }
+  return self.model.checkSSOUser(uname, this.req)
+  .then(function () {
+    return self.model.getUser(uname, pword, function (err, user) {
+      if (err) return done(error('server_error', false, err));
+      if (!user) {
+        return done(error('invalid_grant', 'User credentials are invalid'));
+      }
 
-    self.user = user;
-    self.scope = self.req.body.scope;
+      self.user = user;
+      self.scope = self.req.body.scope;
 
-    done();
-  }, this.req);
+      done();
+    }, self.req);
+  }).catch(function (err) {
+    return done(error('sso_user', err));
+  });
 }
 
 /**

--- a/test/grant.js
+++ b/test/grant.js
@@ -197,6 +197,30 @@ describe('Grant', function() {
         .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
         .expect(400, /client credentials are invalid/i, done);
     });
+
+    it('should detect SSO user', function (done) {
+
+      var app = bootstrap({
+        model: {
+          getClient: function (id, secret, callback) {
+            callback(false, true);
+          },
+          grantTypeAllowed: function (clientId, grantType, callback) {
+            callback(false, true);
+          },
+          checkSSOUser: function fakeSSO (uname) {
+            return Promise.reject('User is SSO'); // Fake SSO validation
+          }
+        },
+        grants: ['password']
+      });
+
+      request(app)
+        .post('/oauth/token')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send(validBody)
+        .expect(403, /User is SSO/i, done);
+    });
   });
 
   describe('check grant type allowed for client (via model)', function () {
@@ -231,6 +255,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -265,6 +290,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -302,6 +328,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -337,6 +364,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -373,6 +401,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -413,6 +442,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -456,6 +486,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -505,6 +536,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -552,6 +584,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -599,6 +632,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -642,6 +676,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },
@@ -677,6 +712,7 @@ describe('Grant', function() {
           grantTypeAllowed: function (clientId, grantType, callback) {
             callback(false, true);
           },
+          checkSSOUser: function (uname) { return Promise.resolve(); },
           getUser: function (uname, pword, callback) {
             callback(false, { id: 1 });
           },

--- a/test/grant.password.js
+++ b/test/grant.password.js
@@ -73,6 +73,7 @@ describe('Granting with password grant type', function () {
         grantTypeAllowed: function (clientId, grantType, callback) {
           callback(false, true);
         },
+        checkSSOUser: function (uname) { return Promise.resolve(); },
         getUser: function (uname, pword, callback) {
           uname.should.equal('thomseddon');
           pword.should.equal('nightworld');
@@ -105,6 +106,7 @@ describe('Granting with password grant type', function () {
         grantTypeAllowed: function (clientId, grantType, callback) {
           callback(false, true);
         },
+        checkSSOUser: function (uname) { return Promise.resolve(); },
         getUser: function (uname, pword, callback) {
           callback(false, { id: 1, mfaEnabled: true });
         },
@@ -140,6 +142,7 @@ describe('Granting with password grant type', function () {
         grantTypeAllowed: function (clientId, grantType, callback) {
           callback(false, true);
         },
+        checkSSOUser: function (uname) { return Promise.resolve(); },
         getUser: function (uname, pword, callback) {
           callback(false, { id: 1, mfaEnabled: false });
         },


### PR DESCRIPTION
Adds an extra step to password grant check, it makes a call to `model.checkSSOUser` if it throws an error the `POST oauth/token` will return with a 403 Forbidden.

This change is required for https://github.com/particle-iot-inc/api-service/pull/1379
[Shortcut story](https://app.shortcut.com/particle/story/117375/don-t-allow-password-login-for-a-user-with-no-password)

Changes can be tested by running `npm run test` (take into account that it requires node v6)