### PR TITLE
Add checkForQueryAccessToken to standard authorise function list

### DIFF
--- a/lib/authorise.js
+++ b/lib/authorise.js
@@ -27,7 +27,8 @@ module.exports = Authorise;
  */
 var fns = [
   checkAuthoriseType,
-  checkScope
+  checkScope,
+  checkForQueryAccessToken
 ];
 
 /**
@@ -141,7 +142,7 @@ function checkImplicitClient (done) {
  * Extract token from request according to RFC6750
  *
  * @param  {Function} done
- * @this   OAuth
+ * @this   Authorise
  */
 function getBearerToken (done) {
   var headerToken = this.req.get('Authorization'),
@@ -193,7 +194,7 @@ function getBearerToken (done) {
  *
  * Check it against model, ensure it's not expired
  * @param  {Function} done
- * @this   OAuth
+ * @this   Authorise
  */
 function checkToken (done) {
   var self = this;
@@ -223,9 +224,8 @@ function checkToken (done) {
  * Check scope
  *
  * @param {Function} done
- * @this  OAuth
+ * @this  Authorise
  */
-
 function checkScope (done) {
   if (!this.model.authoriseScope) return done();
 
@@ -235,5 +235,24 @@ function checkScope (done) {
     if (invalid) return done(error('invalid_scope', invalid));
 
     done();
+  });
+}
+
+/**
+ * Check for query access token and ask model if its allowed to be used
+ * @param {Function} done
+ * @this Authorise
+ */
+function checkForQueryAccessToken(done) {
+  // If no access_token and no provided model method, continue
+  if (!this.req.query.access_token || !this.model.shouldAllowQueryAccessToken) {
+    return done();
+  }
+
+  this.model.shouldAllowQueryAccessToken(this.req, (errorMessage) => {
+    if (!errorMessage) {
+      return done();
+    }
+    return done(error('invalid_request', errorMessage));
   });
 }

--- a/lib/error.js
+++ b/lib/error.js
@@ -21,9 +21,9 @@ module.exports = OAuth2Error;
 /**
  * Error
  *
- * @param {Number} code        Numeric error code
- * @param {String} error       Error descripton
+ * @param {String} error       Error type, determines status code, see below
  * @param {String} description Full error description
+ * @param {Error}  [err]       Original error
  */
 function OAuth2Error (error, description, err) {
   if (!(this instanceof OAuth2Error))
@@ -53,6 +53,7 @@ function OAuth2Error (error, description, err) {
       if (typeof this.message === 'boolean') {
         this.message = 'Invalid scope';
       }
+    // eslint-disable-next-line no-fallthrough
     case 'invalid_grant':
     case 'invalid_request':
       this.code = 400;


### PR DESCRIPTION
`checkForQueryAccessToken` will call `this.model.shouldAllowQueryAccessToken` if its present along with the query access token

API service will implement this method and call launch darkly to check whether to allow this user through and return an error to the callback if false. 