### PR TITLE
feat: [sc-132138] Forward isCustomer to user via refresh_token grant

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -252,7 +252,8 @@ function useRefreshTokenGrant (done) {
         'No user/userId parameter returned from getRefreshToken'));
     }
 
-    self.user = refreshToken.user || { id: refreshToken.userId };
+    // isCustomer will be looked at in model.saveAccessToken to be added to the new token
+    self.user = refreshToken.user || { id: refreshToken.userId, isCustomer: refreshToken.isCustomer };
     self.scope = refreshToken.scope;
 
     if (self.model.revokeRefreshToken) {


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/132138

# Story
* Forward `isCustomer` from refreshToken to `user` obj so we save it to the newly generated access token
