### PR TITLE
Add check for variable type of grantType before calling .match for improved error handling

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -78,7 +78,7 @@ function extractCredentials (done) {
 
   // Grant type
   this.grantType = this.req.body && this.req.body.grant_type;
-  if (!this.grantType || !this.grantType.match(this.config.regex.grantType)) {
+  if (!this.grantType || typeof this.grantType !== 'string' || !this.grantType.match(this.config.regex.grantType)) {
     return done(error('invalid_request',
       'Invalid or missing grant_type parameter'));
   }


### PR DESCRIPTION
Story: https://app.shortcut.com/particle/story/132915/bug-invalid-granttype-type-causes-bad-error-response

Fixes: https://particle-io.sentry.io/issues/6129019539/?alert_rule_id=2322735&alert_type=issue&environment=production&notification_uuid=7485447b-7f3b-4e62-ac3c-0374416f826c&project=5377496&referrer=slack