### PR TITLE
Add eslint and eslint-config-particle, lint script, and fix all the lints!

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,7 @@
+import { particle } from 'eslint-config-particle';
+
+export default particle({
+	rootDir: import.meta.dirname,
+	testGlobals: 'mocha',
+	globalIgnores: ['./examples']
+});

--- a/examples/dynamodb/dal.js
+++ b/examples/dynamodb/dal.js
@@ -1,94 +1,106 @@
-var Dal = function () {
-  this.AWS = require('aws-sdk');
-  this.AWS.config.loadFromPath(__dirname + '/aws.json');
-  //change the endpoint to match your dynamodb endpoint
-  this.db = new this.AWS.DynamoDB({
-    endpoint: "https://dynamodb.us-east-1.amazonaws.com/"
-  });
+'use strict';
+
+const Dal = function () {
+	this.AWS = require('aws-sdk');
+	this.AWS.config.loadFromPath(__dirname + '/aws.json');
+	//change the endpoint to match your dynamodb endpoint
+	this.db = new this.AWS.DynamoDB({
+		endpoint: 'https://dynamodb.us-east-1.amazonaws.com/'
+	});
 };
 
 Dal.prototype = {
-  decodeValue: function (map) {
-    if (typeof map.N !== 'undefined')
-      return parseFloat(map.N);
-    if (typeof map.S !== 'undefined')
-      return map.S;
-    return map.Bl;
-  },
-  decodeValues: function (obj, vals) {
-    var self = this;
-    for (var key in vals) {
-      if (vals.hasOwnProperty(key)) {
-        obj[key] = self.decodeValue(vals[key]);
-      }
-    }
-  },
-  formatAttributes: function (obj) {
-    var item = {};
-    for (var p in obj) {
-      if (obj.hasOwnProperty(p)) {
-        if (obj[p] === 0 || typeof obj[p] == "number") {
-          item[p] = {"N": obj[p].toString()};
-        }
-        else {
-          item[p] = {"S": obj[p]};
-        }
-      }
-    }
-    return item;
-  },
-  deleteEmptyProperties: function (obj) {
-    //DynamoDB does not allow you to store empty values
-    for (var p in obj) {
-      if (!obj.hasOwnProperty(p))
-        continue;
-      if (obj[p] !== 0 && (obj[p] === null || obj[p] === "")) {
-        delete(obj[p]);
-      }
-    }
-  },
-  doGet: function (tableName, keyHash, consistent, callback) {
-    consistent = typeof consistent !== 'undefined' ? consistent : false;
-    var self = this;
-    var result = this.db.getItem({
-      TableName: tableName,
-      Key: keyHash,
-      ConsistentRead: consistent
-    }, function (err, data) {
-      var obj = {};
-      if (err !== null) {
-        if (callback) callback(err, null);
-        return;
-      }
-      if (typeof data.Item != "undefined") {
-        self.decodeValues(obj, data.Item);
-      }
-      if (callback) callback(err, obj);
-    });
-  },
-  doSet: function (obj, tableName, keyHash, callback) {
-    this.deleteEmptyProperties(obj);
-    this.db.putItem({
-      TableName: tableName,
-      Item: this.formatAttributes(obj)
-    }, function (err, data) {
+	decodeValue: function (map) {
+		if (typeof map.N !== 'undefined') {
+			return parseFloat(map.N);
+		}
+		if (typeof map.S !== 'undefined') {
+			return map.S;
+		}
+		return map.Bl;
+	},
+	decodeValues: function (obj, vals) {
+		const self = this;
+		for (const key in vals) {
+			if (vals.hasOwnProperty(key)) {
+				obj[key] = self.decodeValue(vals[key]);
+			}
+		}
+	},
+	formatAttributes: function (obj) {
+		const item = {};
+		for (const p in obj) {
+			if (obj.hasOwnProperty(p)) {
+				if (obj[p] === 0 || typeof obj[p] == 'number') {
+					item[p] = { 'N': obj[p].toString() };
+				} else {
+					item[p] = { 'S': obj[p] };
+				}
+			}
+		}
+		return item;
+	},
+	deleteEmptyProperties: function (obj) {
+		//DynamoDB does not allow you to store empty values
+		for (const p in obj) {
+			if (!obj.hasOwnProperty(p)) {
+				continue;
+			}
+			if (obj[p] !== 0 && (obj[p] === null || obj[p] === '')) {
+				delete (obj[p]);
+			}
+		}
+	},
+	doGet: function (tableName, keyHash, consistent, callback) {
+		consistent = typeof consistent !== 'undefined' ? consistent : false;
+		const self = this;
+		const result = this.db.getItem({
+			TableName: tableName,
+			Key: keyHash,
+			ConsistentRead: consistent
+		}, function (err, data) {
+			const obj = {};
+			if (err !== null) {
+				if (callback) {
+					callback(err, null);
+				}
+				return;
+			}
+			if (typeof data.Item != 'undefined') {
+				self.decodeValues(obj, data.Item);
+			}
+			if (callback) {
+				callback(err, obj);
+			}
+		});
+	},
+	doSet: function (obj, tableName, keyHash, callback) {
+		this.deleteEmptyProperties(obj);
+		this.db.putItem({
+			TableName: tableName,
+			Item: this.formatAttributes(obj)
+		}, function (err, data) {
 
-      if (err !== null) return callback(err, null);
-      callback(err, obj);
-    });
-  },
-  doDelete: function (tableName, keyHash, callback) {
-    this.db.deleteItem({
-        TableName: tableName,
-        Key: keyHash
-      },
-      function (err, data) {
-        if (err !== null) {
-          console.log(err);
-        }
-        if (callback) callback(err, data);
-      });
-  }
+			if (err !== null) {
+				return callback(err, null);
+			}
+			callback(err, obj);
+		});
+	},
+	doDelete: function (tableName, keyHash, callback) {
+		this.db.deleteItem({
+			TableName: tableName,
+			Key: keyHash
+		},
+		function (err, data) {
+			if (err !== null) {
+				console.log(err);
+			}
+			if (callback) {
+				callback(err, data);
+			}
+		});
+	}
 };
 
 module.exports = new Dal();

--- a/examples/dynamodb/index.js
+++ b/examples/dynamodb/index.js
@@ -1,17 +1,19 @@
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  oauthserver = require('../../'); // Would be: 'oauth2-server'
+'use strict';
 
-var app = express();
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	oauthserver = require('../../'); // Would be: 'oauth2-server'
+
+const app = express();
 
 app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use(bodyParser.json());
 
 app.oauth = oauthserver({
-  model: require('./model'),
-  grants: ['password', 'refresh_token'],
-  debug: true
+	model: require('./model'),
+	grants: ['password', 'refresh_token'],
+	debug: true
 });
 
 // Handle token grant requests
@@ -19,67 +21,67 @@ app.all('/oauth/token', app.oauth.grant());
 
 // Show them the "do you authorise xyz app to access your content?" page
 app.get('/oauth/authorise', function (req, res, next) {
-  if (!req.session.user) {
-    // If they aren't logged in, send them to your own login implementation
-    return res.redirect('/login?redirect=' + req.path + '&client_id=' +
+	if (!req.session.user) {
+		// If they aren't logged in, send them to your own login implementation
+		return res.redirect('/login?redirect=' + req.path + '&client_id=' +
         req.query.client_id + '&redirect_uri=' + req.query.redirect_uri);
-  }
+	}
 
-  res.render('authorise', {
-    client_id: req.query.client_id,
-    redirect_uri: req.query.redirect_uri
-  });
+	res.render('authorise', {
+		client_id: req.query.client_id,
+		redirect_uri: req.query.redirect_uri
+	});
 });
 
 // Handle authorise
 app.post('/oauth/authorise', function (req, res, next) {
-  if (!req.session.user) {
-    return res.redirect('/login?client_id=' + req.query.client_id +
+	if (!req.session.user) {
+		return res.redirect('/login?client_id=' + req.query.client_id +
       '&redirect_uri=' + req.query.redirect_uri);
-  }
+	}
 
-  next();
+	next();
 }, app.oauth.authCodeGrant(function (req, next) {
-  // The first param should to indicate an error
-  // The second param should a bool to indicate if the user did authorise the app
-  // The third param should for the user/uid (only used for passing to saveAuthCode)
-  next(null, req.body.allow === 'yes', req.session.user.id, req.session.user);
+	// The first param should to indicate an error
+	// The second param should a bool to indicate if the user did authorise the app
+	// The third param should for the user/uid (only used for passing to saveAuthCode)
+	next(null, req.body.allow === 'yes', req.session.user.id, req.session.user);
 }));
 
 // Show login
 app.get('/login', function (req, res, next) {
-  res.render('login', {
-    redirect: req.query.redirect,
-    client_id: req.query.client_id,
-    redirect_uri: req.query.redirect_uri
-  });
+	res.render('login', {
+		redirect: req.query.redirect,
+		client_id: req.query.client_id,
+		redirect_uri: req.query.redirect_uri
+	});
 });
 
 // Handle login
 app.post('/login', function (req, res, next) {
-  // Insert your own login mechanism
-  if (req.body.email !== 'thom@nightworld.com') {
-    res.render('login', {
-      redirect: req.body.redirect,
-      client_id: req.body.client_id,
-      redirect_uri: req.body.redirect_uri
-    });
-  } else {
-    // Successful logins should send the user back to the /oauth/authorise
-    // with the client_id and redirect_uri (you could store these in the session)
-    return res.redirect((req.body.redirect || '/home') + '?client_id=' +
+	// Insert your own login mechanism
+	if (req.body.email !== 'thom@nightworld.com') {
+		res.render('login', {
+			redirect: req.body.redirect,
+			client_id: req.body.client_id,
+			redirect_uri: req.body.redirect_uri
+		});
+	} else {
+		// Successful logins should send the user back to the /oauth/authorise
+		// with the client_id and redirect_uri (you could store these in the session)
+		return res.redirect((req.body.redirect || '/home') + '?client_id=' +
         req.body.client_id + '&redirect_uri=' + req.body.redirect_uri);
-  }
+	}
 });
 
 app.get('/secret', app.oauth.authorise(), function (req, res) {
-  // Will require a valid access_token
-  res.send('Secret area');
+	// Will require a valid access_token
+	res.send('Secret area');
 });
 
 app.get('/public', function (req, res) {
-  // Does not require an access_token
-  res.send('Public area');
+	// Does not require an access_token
+	res.send('Public area');
 });
 
 // Error handling

--- a/examples/dynamodb/model.js
+++ b/examples/dynamodb/model.js
@@ -14,128 +14,138 @@
  * limitations under the License.
  */
 
-var dal = require('./dal.js');
+'use strict';
+
+const dal = require('./dal.js');
 model = module.exports;
 
-var OAuthAccessTokenTable = "oauth2accesstoken";
-var OAuthAuthCodeTable = "oauth2authcode";
-var OAuthRefreshTokenTable = "oauth2refreshtoken";
-var OAuthClientTable = "oauth2client";
-var OAuthUserTable = "userid_map";
+const OAuthAccessTokenTable = 'oauth2accesstoken';
+const OAuthAuthCodeTable = 'oauth2authcode';
+const OAuthRefreshTokenTable = 'oauth2refreshtoken';
+const OAuthClientTable = 'oauth2client';
+const OAuthUserTable = 'userid_map';
 
 //
 // oauth2-server callbacks
 //
 model.getAccessToken = function (bearerToken, callback) {
-  console.log('in getAccessToken (bearerToken: ' + bearerToken + ')');
+	console.log('in getAccessToken (bearerToken: ' + bearerToken + ')');
 
-  dal.doGet(OAuthAccessTokenTable,
-    {"accessToken": {"S": bearerToken}}, true, function(err, data) {
-      if (data && data.expires) {
-        data.expires = new Date(data.expires * 1000);
-      }
-      callback(err, data);
-    });
+	dal.doGet(OAuthAccessTokenTable,
+		{ 'accessToken': { 'S': bearerToken } }, true, function(err, data) {
+			if (data && data.expires) {
+				data.expires = new Date(data.expires * 1000);
+			}
+			callback(err, data);
+		});
 };
 
 model.getClient = function (clientId, clientSecret, callback) {
-  console.log('in getClient (clientId: ' + clientId + ', clientSecret: ' + clientSecret + ')');
-  dal.doGet(OAuthClientTable, { clientId: { S: clientId }}, true,
-      function(err, data) {
-    if (err || !data) return callback(err, data);
+	console.log('in getClient (clientId: ' + clientId + ', clientSecret: ' + clientSecret + ')');
+	dal.doGet(OAuthClientTable, { clientId: { S: clientId } }, true,
+		function(err, data) {
+			if (err || !data) {
+				return callback(err, data);
+			}
 
-    if (clientSecret !== null && data.clientSecret !== clientSecret) {
-      return callback();
-    }
+			if (clientSecret !== null && data.clientSecret !== clientSecret) {
+				return callback();
+			}
 
-    callback(null, data);
-  });
+			callback(null, data);
+		});
 };
 
 // This will very much depend on your setup, I wouldn't advise doing anything exactly like this but
 // it gives an example of how to use the method to restrict certain grant types
-var authorizedClientIds = ['abc1', 'def2'];
+const authorizedClientIds = ['abc1', 'def2'];
 model.grantTypeAllowed = function (clientId, grantType, callback) {
-  console.log('in grantTypeAllowed (clientId: ' + clientId + ', grantType: ' + grantType + ')');
+	console.log('in grantTypeAllowed (clientId: ' + clientId + ', grantType: ' + grantType + ')');
 
-  if (grantType === 'password') {
-    return callback(false, authorizedClientIds.indexOf(clientId) >= 0);
-  }
+	if (grantType === 'password') {
+		return callback(false, authorizedClientIds.indexOf(clientId) >= 0);
+	}
 
-  callback(false, true);
+	callback(false, true);
 };
 
 model.saveAccessToken = function (accessToken, clientId, expires, user, callback) {
-  console.log('in saveAccessToken (accessToken: ' + accessToken + ', clientId: ' + clientId + ', userId: ' + user.id + ', expires: ' + expires + ')');
+	console.log('in saveAccessToken (accessToken: ' + accessToken + ', clientId: ' + clientId + ', userId: ' + user.id + ', expires: ' + expires + ')');
 
-  var token = {
-    accessToken: accessToken,
-    clientId: clientId,
-    userId: user.id
-  };
+	const token = {
+		accessToken: accessToken,
+		clientId: clientId,
+		userId: user.id
+	};
 
-  if (expires) token.expires = parseInt(expires / 1000, 10);
-  console.log('saving', token);
+	if (expires) {
+		token.expires = parseInt(expires / 1000, 10);
+	}
+	console.log('saving', token);
 
-  dal.doSet(token, OAuthAccessTokenTable, { accessToken: { S: accessToken }}, callback);
+	dal.doSet(token, OAuthAccessTokenTable, { accessToken: { S: accessToken } }, callback);
 };
 
 model.saveRefreshToken = function (refreshToken, clientId, expires, user, callback) {
-  console.log('in saveRefreshToken (refreshToken: ' + refreshToken + ', clientId: ' + clientId + ', userId: ' + user.id + ', expires: ' + expires + ')');
+	console.log('in saveRefreshToken (refreshToken: ' + refreshToken + ', clientId: ' + clientId + ', userId: ' + user.id + ', expires: ' + expires + ')');
 
-  var token = {
-    refreshToken: refreshToken,
-    clientId: clientId,
-    userId: user.id
-  };
+	const token = {
+		refreshToken: refreshToken,
+		clientId: clientId,
+		userId: user.id
+	};
 
-  if (expires) token.expires = parseInt(expires / 1000, 10);
-  console.log('saving', token);
+	if (expires) {
+		token.expires = parseInt(expires / 1000, 10);
+	}
+	console.log('saving', token);
 
-  dal.doSet(token, OAuthRefreshTokenTable, { refreshToken: { S: refreshToken }}, callback);
+	dal.doSet(token, OAuthRefreshTokenTable, { refreshToken: { S: refreshToken } }, callback);
 };
 
 model.getRefreshToken = function (bearerToken, callback) {
-  console.log("in getRefreshToken (bearerToken: " + bearerToken + ")");
+	console.log('in getRefreshToken (bearerToken: ' + bearerToken + ')');
 
-  dal.doGet(OAuthRefreshTokenTable, { refreshToken: { S: bearerToken }}, true, function(err, data) {
-      if (data && data.expires) {
-        data.expires = new Date(data.expires * 1000);
-      }
-      callback(err, data);
-    });
+	dal.doGet(OAuthRefreshTokenTable, { refreshToken: { S: bearerToken } }, true, function(err, data) {
+		if (data && data.expires) {
+			data.expires = new Date(data.expires * 1000);
+		}
+		callback(err, data);
+	});
 };
 
 model.revokeRefreshToken = function(bearerToken, callback) {
-  console.log("in revokeRefreshToken (bearerToken: " + bearerToken + ")");
+	console.log('in revokeRefreshToken (bearerToken: ' + bearerToken + ')');
 
-  dal.doDelete(OAuthRefreshTokenTable, { refreshToken: { S: bearerToken }}, callback);
+	dal.doDelete(OAuthRefreshTokenTable, { refreshToken: { S: bearerToken } }, callback);
 };
 
 model.getAuthCode = function (bearerCode, callback) {
-  console.log("in getAuthCode (bearerCode: " + bearerCode + ")");
+	console.log('in getAuthCode (bearerCode: ' + bearerCode + ')');
 
-  dal.doGet(OAuthAuthCodeTable, { authCode: { S: bearerCode }}, true, function(err, data) {
-      if (data && data.expires) {
-        data.expires = new Date(data.expires * 1000);
-      }
-      callback(err, data);
-    });
+	dal.doGet(OAuthAuthCodeTable, { authCode: { S: bearerCode } }, true, function(err, data) {
+		if (data && data.expires) {
+			data.expires = new Date(data.expires * 1000);
+		}
+		callback(err, data);
+	});
 };
 
 model.saveAuthCode = function (authCode, clientId, expires, user, callback) {
-  console.log('in saveAuthCode (authCode: ' + authCode + ', clientId: ' + clientId + ', userId: ' + user.id + ', expires: ' + expires + ')');
+	console.log('in saveAuthCode (authCode: ' + authCode + ', clientId: ' + clientId + ', userId: ' + user.id + ', expires: ' + expires + ')');
 
-  var code = {
-    authCode: authCode,
-    clientId: clientId,
-    userId: user.id
-  };
+	const code = {
+		authCode: authCode,
+		clientId: clientId,
+		userId: user.id
+	};
 
-  if (expires) code.expires = parseInt(expires / 1000, 10);
-  console.log("saving", code);
+	if (expires) {
+		code.expires = parseInt(expires / 1000, 10);
+	}
+	console.log('saving', code);
 
-  dal.doSet(code, OAuthAuthCodeTable, { authCode: { S: authCode }}, callback);
+	dal.doSet(code, OAuthAuthCodeTable, { authCode: { S: authCode } }, callback);
 };
 
 
@@ -143,10 +153,12 @@ model.saveAuthCode = function (authCode, clientId, expires, user, callback) {
  * Required to support password grant type
  */
 model.getUser = function (username, password, callback) {
-  console.log('in getUser (username: ' + username + ', password: ' + password + ')');
+	console.log('in getUser (username: ' + username + ', password: ' + password + ')');
 
-  dal.doGet(OAuthUserTable, { id: { S: "email:" + username}}, true, function(err, data) {
-      if (err) return callback(err);
-      callback(null, { id: data.userId });
-    });
+	dal.doGet(OAuthUserTable, { id: { S: 'email:' + username } }, true, function(err, data) {
+		if (err) {
+			return callback(err);
+		}
+		callback(null, { id: data.userId });
+	});
 };

--- a/examples/memory/model.js
+++ b/examples/memory/model.js
@@ -1,38 +1,40 @@
-var model = module.exports;
+'use strict';
+
+const model = module.exports;
 
 // In-memory datastores:
-var oauthAccessTokens = [],
-  oauthRefreshTokens = [],
-  oauthClients = [
-    {
-      clientId : 'thom',
-      clientSecret : 'nightworld',
-      redirectUri : ''
-    }
-  ],
-  authorizedClientIds = {
-    password: [
-      'thom'
-    ],
-    refresh_token: [
-      'thom'
-    ]
-  },
-  users = [
-    {
-      id : '123',
-      username: 'thomseddon',
-      password: 'nightworld'
-    }
-  ];
+const oauthAccessTokens = [],
+	oauthRefreshTokens = [],
+	oauthClients = [
+		{
+			clientId : 'thom',
+			clientSecret : 'nightworld',
+			redirectUri : ''
+		}
+	],
+	authorizedClientIds = {
+		password: [
+			'thom'
+		],
+		refresh_token: [
+			'thom'
+		]
+	},
+	users = [
+		{
+			id : '123',
+			username: 'thomseddon',
+			password: 'nightworld'
+		}
+	];
 
 // Debug function to dump the state of the data stores
 model.dump = function() {
-  console.log('oauthAccessTokens', oauthAccessTokens);
-  console.log('oauthClients', oauthClients);
-  console.log('authorizedClientIds', authorizedClientIds);
-  console.log('oauthRefreshTokens', oauthRefreshTokens);
-  console.log('users', users);
+	console.log('oauthAccessTokens', oauthAccessTokens);
+	console.log('oauthClients', oauthClients);
+	console.log('authorizedClientIds', authorizedClientIds);
+	console.log('oauthRefreshTokens', oauthRefreshTokens);
+	console.log('users', users);
 };
 
 /*
@@ -40,72 +42,72 @@ model.dump = function() {
  */
 
 model.getAccessToken = function (bearerToken, callback) {
-  for(var i = 0, len = oauthAccessTokens.length; i < len; i++) {
-    var elem = oauthAccessTokens[i];
-    if(elem.accessToken === bearerToken) {
-      return callback(false, elem);
-    }
-  }
-  callback(false, false);
+	for (let i = 0, len = oauthAccessTokens.length; i < len; i++) {
+		const elem = oauthAccessTokens[i];
+		if (elem.accessToken === bearerToken) {
+			return callback(false, elem);
+		}
+	}
+	callback(false, false);
 };
 
 model.getRefreshToken = function (bearerToken, callback) {
-  for(var i = 0, len = oauthRefreshTokens.length; i < len; i++) {
-    var elem = oauthRefreshTokens[i];
-    if(elem.refreshToken === bearerToken) {
-      return callback(false, elem);
-    }
-  }
-  callback(false, false);
+	for (let i = 0, len = oauthRefreshTokens.length; i < len; i++) {
+		const elem = oauthRefreshTokens[i];
+		if (elem.refreshToken === bearerToken) {
+			return callback(false, elem);
+		}
+	}
+	callback(false, false);
 };
 
 model.getClient = function (clientId, clientSecret, callback) {
-  for(var i = 0, len = oauthClients.length; i < len; i++) {
-    var elem = oauthClients[i];
-    if(elem.clientId === clientId &&
+	for (let i = 0, len = oauthClients.length; i < len; i++) {
+		const elem = oauthClients[i];
+		if (elem.clientId === clientId &&
       (clientSecret === null || elem.clientSecret === clientSecret)) {
-      return callback(false, elem);
-    }
-  }
-  callback(false, false);
+			return callback(false, elem);
+		}
+	}
+	callback(false, false);
 };
 
 model.grantTypeAllowed = function (clientId, grantType, callback) {
-  callback(false, authorizedClientIds[grantType] &&
+	callback(false, authorizedClientIds[grantType] &&
     authorizedClientIds[grantType].indexOf(clientId.toLowerCase()) >= 0);
 };
 
 model.saveAccessToken = function (accessToken, clientId, expires, userId, callback) {
-  oauthAccessTokens.unshift({
-    accessToken: accessToken,
-    clientId: clientId,
-    userId: userId,
-    expires: expires
-  });
+	oauthAccessTokens.unshift({
+		accessToken: accessToken,
+		clientId: clientId,
+		userId: userId,
+		expires: expires
+	});
 
-  callback(false);
+	callback(false);
 };
 
 model.saveRefreshToken = function (refreshToken, clientId, expires, userId, callback) {
-  oauthRefreshTokens.unshift({
-    refreshToken: refreshToken,
-    clientId: clientId,
-    userId: userId,
-    expires: expires
-  });
+	oauthRefreshTokens.unshift({
+		refreshToken: refreshToken,
+		clientId: clientId,
+		userId: userId,
+		expires: expires
+	});
 
-  callback(false);
+	callback(false);
 };
 
 /*
  * Required to support password grant type
  */
 model.getUser = function (username, password, callback) {
-  for(var i = 0, len = users.length; i < len; i++) {
-    var elem = users[i];
-    if(elem.username === username && elem.password === password) {
-      return callback(false, elem);
-    }
-  }
-  callback(false, false);
+	for (let i = 0, len = users.length; i < len; i++) {
+		const elem = users[i];
+		if (elem.username === username && elem.password === password) {
+			return callback(false, elem);
+		}
+	}
+	callback(false, false);
 };

--- a/examples/mongodb/model.js
+++ b/examples/mongodb/model.js
@@ -14,39 +14,41 @@
  * limitations under the License.
  */
 
-var mongoose = require('mongoose'),
-  Schema = mongoose.Schema,
-  model = module.exports;
+'use strict';
+
+const mongoose = require('mongoose'),
+	Schema = mongoose.Schema,
+	model = module.exports;
 
 //
 // Schemas definitions
 //
-var OAuthAccessTokensSchema = new Schema({
-  accessToken: { type: String },
-  clientId: { type: String },
-  userId: { type: String },
-  expires: { type: Date }
+const OAuthAccessTokensSchema = new Schema({
+	accessToken: { type: String },
+	clientId: { type: String },
+	userId: { type: String },
+	expires: { type: Date }
 });
 
-var OAuthRefreshTokensSchema = new Schema({
-  refreshToken: { type: String },
-  clientId: { type: String },
-  userId: { type: String },
-  expires: { type: Date }
+const OAuthRefreshTokensSchema = new Schema({
+	refreshToken: { type: String },
+	clientId: { type: String },
+	userId: { type: String },
+	expires: { type: Date }
 });
 
-var OAuthClientsSchema = new Schema({
-  clientId: { type: String },
-  clientSecret: { type: String },
-  redirectUri: { type: String }
+const OAuthClientsSchema = new Schema({
+	clientId: { type: String },
+	clientSecret: { type: String },
+	redirectUri: { type: String }
 });
 
-var OAuthUsersSchema = new Schema({
-  username: { type: String },
-  password: { type: String },
-  firstname: { type: String },
-  lastname: { type: String },
-  email: { type: String, default: '' }
+const OAuthUsersSchema = new Schema({
+	username: { type: String },
+	password: { type: String },
+	firstname: { type: String },
+	lastname: { type: String },
+	email: { type: String, default: '' }
 });
 
 mongoose.model('OAuthAccessTokens', OAuthAccessTokensSchema);
@@ -54,84 +56,86 @@ mongoose.model('OAuthRefreshTokens', OAuthRefreshTokensSchema);
 mongoose.model('OAuthClients', OAuthClientsSchema);
 mongoose.model('OAuthUsers', OAuthUsersSchema);
 
-var OAuthAccessTokensModel = mongoose.model('OAuthAccessTokens'),
-  OAuthRefreshTokensModel = mongoose.model('OAuthRefreshTokens'),
-  OAuthClientsModel = mongoose.model('OAuthClients'),
-  OAuthUsersModel = mongoose.model('OAuthUsers');
+const OAuthAccessTokensModel = mongoose.model('OAuthAccessTokens'),
+	OAuthRefreshTokensModel = mongoose.model('OAuthRefreshTokens'),
+	OAuthClientsModel = mongoose.model('OAuthClients'),
+	OAuthUsersModel = mongoose.model('OAuthUsers');
 
 //
 // oauth2-server callbacks
 //
 model.getAccessToken = function (bearerToken, callback) {
-  console.log('in getAccessToken (bearerToken: ' + bearerToken + ')');
+	console.log('in getAccessToken (bearerToken: ' + bearerToken + ')');
 
-  OAuthAccessTokensModel.findOne({ accessToken: bearerToken }, callback);
+	OAuthAccessTokensModel.findOne({ accessToken: bearerToken }, callback);
 };
 
 model.getClient = function (clientId, clientSecret, callback) {
-  console.log('in getClient (clientId: ' + clientId + ', clientSecret: ' + clientSecret + ')');
-  if (clientSecret === null) {
-    return OAuthClientsModel.findOne({ clientId: clientId }, callback);
-  }
-  OAuthClientsModel.findOne({ clientId: clientId, clientSecret: clientSecret }, callback);
+	console.log('in getClient (clientId: ' + clientId + ', clientSecret: ' + clientSecret + ')');
+	if (clientSecret === null) {
+		return OAuthClientsModel.findOne({ clientId: clientId }, callback);
+	}
+	OAuthClientsModel.findOne({ clientId: clientId, clientSecret: clientSecret }, callback);
 };
 
 // This will very much depend on your setup, I wouldn't advise doing anything exactly like this but
 // it gives an example of how to use the method to resrict certain grant types
-var authorizedClientIds = ['s6BhdRkqt3', 'toto'];
+const authorizedClientIds = ['s6BhdRkqt3', 'toto'];
 model.grantTypeAllowed = function (clientId, grantType, callback) {
-  console.log('in grantTypeAllowed (clientId: ' + clientId + ', grantType: ' + grantType + ')');
+	console.log('in grantTypeAllowed (clientId: ' + clientId + ', grantType: ' + grantType + ')');
 
-  if (grantType === 'password') {
-    return callback(false, authorizedClientIds.indexOf(clientId) >= 0);
-  }
+	if (grantType === 'password') {
+		return callback(false, authorizedClientIds.indexOf(clientId) >= 0);
+	}
 
-  callback(false, true);
+	callback(false, true);
 };
 
 model.saveAccessToken = function (token, clientId, expires, userId, callback) {
-  console.log('in saveAccessToken (token: ' + token + ', clientId: ' + clientId + ', userId: ' + userId + ', expires: ' + expires + ')');
+	console.log('in saveAccessToken (token: ' + token + ', clientId: ' + clientId + ', userId: ' + userId + ', expires: ' + expires + ')');
 
-  var accessToken = new OAuthAccessTokensModel({
-    accessToken: token,
-    clientId: clientId,
-    userId: userId,
-    expires: expires
-  });
+	const accessToken = new OAuthAccessTokensModel({
+		accessToken: token,
+		clientId: clientId,
+		userId: userId,
+		expires: expires
+	});
 
-  accessToken.save(callback);
+	accessToken.save(callback);
 };
 
 /*
  * Required to support password grant type
  */
 model.getUser = function (username, password, callback) {
-  console.log('in getUser (username: ' + username + ', password: ' + password + ')');
+	console.log('in getUser (username: ' + username + ', password: ' + password + ')');
 
-  OAuthUsersModel.findOne({ username: username, password: password }, function(err, user) {
-    if(err) return callback(err);
-    callback(null, user._id);
-  });
+	OAuthUsersModel.findOne({ username: username, password: password }, function(err, user) {
+		if (err) {
+			return callback(err);
+		}
+		callback(null, user._id);
+	});
 };
 
 /*
  * Required to support refreshToken grant type
  */
 model.saveRefreshToken = function (token, clientId, expires, userId, callback) {
-  console.log('in saveRefreshToken (token: ' + token + ', clientId: ' + clientId +', userId: ' + userId + ', expires: ' + expires + ')');
+	console.log('in saveRefreshToken (token: ' + token + ', clientId: ' + clientId + ', userId: ' + userId + ', expires: ' + expires + ')');
 
-  var refreshToken = new OAuthRefreshTokensModel({
-    refreshToken: token,
-    clientId: clientId,
-    userId: userId,
-    expires: expires
-  });
+	const refreshToken = new OAuthRefreshTokensModel({
+		refreshToken: token,
+		clientId: clientId,
+		userId: userId,
+		expires: expires
+	});
 
-  refreshToken.save(callback);
+	refreshToken.save(callback);
 };
 
 model.getRefreshToken = function (refreshToken, callback) {
-  console.log('in getRefreshToken (refreshToken: ' + refreshToken + ')');
+	console.log('in getRefreshToken (refreshToken: ' + refreshToken + ')');
 
-  OAuthRefreshTokensModel.findOne({ refreshToken: refreshToken }, callback);
+	OAuthRefreshTokensModel.findOne({ refreshToken: refreshToken }, callback);
 };

--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -1,17 +1,17 @@
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  oauthserver = require('../../'); // Would be: 'oauth2-server'
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	oauthserver = require('../../'); // Would be: 'oauth2-server'
 
-var app = express();
+const app = express();
 
 app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use(bodyParser.json());
 
 app.oauth = oauthserver({
-  model: require('./model'),
-  grants: ['auth_code', 'password'],
-  debug: true
+	model: require('./model'),
+	grants: ['auth_code', 'password'],
+	debug: true
 });
 
 // Handle token grant requests
@@ -19,73 +19,73 @@ app.all('/oauth/token', app.oauth.grant());
 
 // Show them the "do you authorise xyz app to access your content?" page
 app.get('/oauth/authorise', function (req, res, next) {
-  if (!req.session.user) {
-    // If they aren't logged in, send them to your own login implementation
-    return res.redirect('/login?redirect=' + req.path + '&client_id=' +
+	if (!req.session.user) {
+		// If they aren't logged in, send them to your own login implementation
+		return res.redirect('/login?redirect=' + req.path + '&client_id=' +
         req.query.client_id + '&redirect_uri=' + req.query.redirect_uri);
-  }
+	}
 
-  res.render('authorise', {
-    client_id: req.query.client_id,
-    redirect_uri: req.query.redirect_uri
-  });
+	res.render('authorise', {
+		client_id: req.query.client_id,
+		redirect_uri: req.query.redirect_uri
+	});
 });
 
 // Handle authorise
 app.post('/oauth/authorise', function (req, res, next) {
-  if (!req.session.user) {
-    return res.redirect('/login?client_id=' + req.query.client_id +
+	if (!req.session.user) {
+		return res.redirect('/login?client_id=' + req.query.client_id +
       '&redirect_uri=' + req.query.redirect_uri);
-  }
+	}
 
-  next();
+	next();
 }, app.oauth.authCodeGrant(function (req, next) {
-  // The first param should to indicate an error
-  // The second param should a bool to indicate if the user did authorise the app
-  // The third param should for the user/uid (only used for passing to saveAuthCode)
-  next(null, req.body.allow === 'yes', req.session.user.id, req.session.user);
+	// The first param should to indicate an error
+	// The second param should a bool to indicate if the user did authorise the app
+	// The third param should for the user/uid (only used for passing to saveAuthCode)
+	next(null, req.body.allow === 'yes', req.session.user.id, req.session.user);
 }));
 
 // Show login
 app.get('/login', function (req, res, next) {
-  res.render('login', {
-    redirect: req.query.redirect,
-    client_id: req.query.client_id,
-    redirect_uri: req.query.redirect_uri
-  });
+	res.render('login', {
+		redirect: req.query.redirect,
+		client_id: req.query.client_id,
+		redirect_uri: req.query.redirect_uri
+	});
 });
 
 // Handle login
 app.post('/login', function (req, res, next) {
-  // Insert your own login mechanism
-  if (req.body.email !== 'thom@nightworld.com') {
-    res.render('login', {
-      redirect: req.body.redirect,
-      client_id: req.body.client_id,
-      redirect_uri: req.body.redirect_uri
-    });
-  } else {
-    // Successful logins should send the user back to the /oauth/authorise
-    // with the client_id and redirect_uri (you could store these in the session)
-    return res.redirect((req.body.redirect || '/home') + '?client_id=' +
+	// Insert your own login mechanism
+	if (req.body.email !== 'thom@nightworld.com') {
+		res.render('login', {
+			redirect: req.body.redirect,
+			client_id: req.body.client_id,
+			redirect_uri: req.body.redirect_uri
+		});
+	} else {
+		// Successful logins should send the user back to the /oauth/authorise
+		// with the client_id and redirect_uri (you could store these in the session)
+		return res.redirect((req.body.redirect || '/home') + '?client_id=' +
         req.body.client_id + '&redirect_uri=' + req.body.redirect_uri);
-  }
+	}
 });
 
 app.get('/secret', app.oauth.authorise(), function (req, res) {
-  // Will require a valid access_token
-  res.send('Secret area');
+	// Will require a valid access_token
+	res.send('Secret area');
 });
 
 app.get('/scoped', app.oauth.authorise(), app.oauth.scope('demo'),
-    function (req, res) {
-  // Will require that the access_token possesses the 'demo' scope key
-  res.send('Secret and scope-controlled area');
-});
+	function (req, res) {
+		// Will require that the access_token possesses the 'demo' scope key
+		res.send('Secret and scope-controlled area');
+	});
 
 app.get('/public', function (req, res) {
-  // Does not require an access_token
-  res.send('Public area');
+	// Does not require an access_token
+	res.send('Public area');
 });
 
 // Error handling

--- a/examples/postgresql/model.js
+++ b/examples/postgresql/model.js
@@ -14,150 +14,168 @@
  * limitations under the License.
  */
 
-var pg = require('pg'),
-  model = module.exports,
-  connString = process.env.DATABASE_URL;
+const pg = require('pg'),
+	model = module.exports,
+	connString = process.env.DATABASE_URL;
 
 /*
  * Required
  */
 
 model.getAccessToken = function (bearerToken, callback) {
-  pg.connect(connString, function (err, client, done) {
-    if (err) return callback(err);
-    client.query('SELECT access_token, scope, client_id, expires, user_id FROM oauth_access_tokens ' +
+	pg.connect(connString, function (err, client, done) {
+		if (err) {
+			return callback(err);
+		}
+		client.query('SELECT access_token, scope, client_id, expires, user_id FROM oauth_access_tokens ' +
         'WHERE access_token = $1', [bearerToken], function (err, result) {
-      if (err || !result.rowCount) return callback(err);
-      // This object will be exposed in req.oauth.token
-      // The user_id field will be exposed in req.user (req.user = { id: "..." }) however if
-      // an explicit user object is included (token.user, must include id) it will be exposed
-      // in req.user instead
-      var token = result.rows[0];
-      callback(null, {
-        accessToken: token.access_token,
-        clientId: token.client_id,
-        expires: token.expires,
-        userId: token.userId,
-        scope: token.scope.split(' ') // Assumes a flat, space-delimited scope string
-      });
-      done();
-    });
-  });
+			if (err || !result.rowCount) {
+				return callback(err);
+			}
+			// This object will be exposed in req.oauth.token
+			// The user_id field will be exposed in req.user (req.user = { id: "..." }) however if
+			// an explicit user object is included (token.user, must include id) it will be exposed
+			// in req.user instead
+			const token = result.rows[0];
+			callback(null, {
+				accessToken: token.access_token,
+				clientId: token.client_id,
+				expires: token.expires,
+				userId: token.userId,
+				scope: token.scope.split(' ') // Assumes a flat, space-delimited scope string
+			});
+			done();
+		});
+	});
 };
 
 model.getClient = function (clientId, clientSecret, callback) {
-  pg.connect(connString, function (err, client, done) {
-    if (err) return callback(err);
+	pg.connect(connString, function (err, client, done) {
+		if (err) {
+			return callback(err);
+		}
 
-    client.query('SELECT client_id, client_secret, redirect_uri, valid_scopes, default_scope FROM oauth_clients WHERE ' +
+		client.query('SELECT client_id, client_secret, redirect_uri, valid_scopes, default_scope FROM oauth_clients WHERE ' +
       'client_id = $1', [clientId], function (err, result) {
-      if (err || !result.rowCount) return callback(err);
+			if (err || !result.rowCount) {
+				return callback(err);
+			}
 
-      var client = result.rows[0];
+			const client = result.rows[0];
 
-      if (clientSecret !== null && client.client_secret !== clientSecret) return callback();
+			if (clientSecret !== null && client.client_secret !== clientSecret) {
+				return callback();
+			}
 
-      // This object will be exposed in req.oauth.client
-      callback(null, {
-        clientId: client.client_id,
-        clientSecret: client.client_secret,
-        validScopes: client.valid_scopes,
-        defaultScope: client.default_scope
-      });
-      done();
-    });
-  });
+			// This object will be exposed in req.oauth.client
+			callback(null, {
+				clientId: client.client_id,
+				clientSecret: client.client_secret,
+				validScopes: client.valid_scopes,
+				defaultScope: client.default_scope
+			});
+			done();
+		});
+	});
 };
 
 model.getRefreshToken = function (bearerToken, callback) {
-  pg.connect(connString, function (err, client, done) {
-    if (err) return callback(err);
-    client.query('SELECT refresh_token, scope, client_id, expires, user_id FROM oauth_refresh_tokens ' +
+	pg.connect(connString, function (err, client, done) {
+		if (err) {
+			return callback(err);
+		}
+		client.query('SELECT refresh_token, scope, client_id, expires, user_id FROM oauth_refresh_tokens ' +
       'WHERE refresh_token = $1', [bearerToken], function(err, result) {
 	  callback(err, result.rowCount ? result.rows[0] : false);
-      done();
+			done();
+		});
 	});
-  });
 };
 
 // This will very much depend on your setup, I wouldn't advise doing anything exactly like this but
 // it gives an example of how to use the method to resrict certain grant types
-var authorizedClientIds = ['abc1', 'def2'];
+const authorizedClientIds = ['abc1', 'def2'];
 model.grantTypeAllowed = function (clientId, grantType, callback) {
-  if (grantType === 'password') {
-    return callback(false, authorizedClientIds.indexOf(clientId.toLowerCase()) >= 0);
-  }
+	if (grantType === 'password') {
+		return callback(false, authorizedClientIds.indexOf(clientId.toLowerCase()) >= 0);
+	}
 
-  callback(false, true);
+	callback(false, true);
 };
 
 model.saveAccessToken = function (accessToken, clientId, expires, userId, scope, callback) {
-  pg.connect(connString, function (err, client, done) {
-    if (err) return callback(err);
-    client.query('INSERT INTO oauth_access_tokens(access_token, client_id, user_id, scope, expires) ' +
+	pg.connect(connString, function (err, client, done) {
+		if (err) {
+			return callback(err);
+		}
+		client.query('INSERT INTO oauth_access_tokens(access_token, client_id, user_id, scope, expires) ' +
         'VALUES ($1, $2, $3, $4, $5)', [accessToken, clientId, userId, scope, expires],
-        function (err, result) {
-      callback(err);
-      done();
-    });
-  });
+		function (err, result) {
+			callback(err);
+			done();
+		});
+	});
 };
 
 model.saveRefreshToken = function (refreshToken, clientId, expires, userId, scope, callback) {
-  pg.connect(connString, function (err, client, done) {
-    if (err) return callback(err);
+	pg.connect(connString, function (err, client, done) {
+		if (err) {
+			return callback(err);
+		}
 
-    client.query('INSERT INTO oauth_refresh_tokens(refresh_token, client_id, ' +
+		client.query('INSERT INTO oauth_refresh_tokens(refresh_token, client_id, ' +
         'user_id, scope, expires) VALUES ($1, $2, $3, $4, $5)',
-        [refreshToken, clientId, userId, scope, expires],
-        function (err, result) {
-          callback(err);
-          done();
-        });
-  });
+		[refreshToken, clientId, userId, scope, expires],
+		function (err, result) {
+			callback(err);
+			done();
+		});
+	});
 };
 
 model.authoriseScope = function (accessToken, scope, callback) {
-  var hasScope = accessToken.scope.indexOf(scope) !== -1;
+	const hasScope = accessToken.scope.indexOf(scope) !== -1;
 
-  // You may pass anything from a simple string, as this example illustrates,
-  // to representations including scopes and subscopes such as
-  // { "account": [ "edit" ] }
-  return callback(false, hasScope ? false : 'Missing scope: ' + scope);
+	// You may pass anything from a simple string, as this example illustrates,
+	// to representations including scopes and subscopes such as
+	// { "account": [ "edit" ] }
+	return callback(false, hasScope ? false : 'Missing scope: ' + scope);
 };
 
 model.validateScope = function (scope, client, user, callback) {
-  // Sanitize the requested scope string against a client-specific set of valid scope keys
-  // and the scopes the user actually is allowed to use (if any).
-  // You could choose to strip invalid keys, or return an error message
-  var requestedScope = scope || client.defaultScope || '';
-  var requestedScopes = requestedScope.split(' ');
-  var validScopes = client.validScopes.split(' ');
-  var isValid = !requestedScope || requestedScopes.every(function(key) {
-        return validScopes.indexOf(key) !== -1;
-      });
+	// Sanitize the requested scope string against a client-specific set of valid scope keys
+	// and the scopes the user actually is allowed to use (if any).
+	// You could choose to strip invalid keys, or return an error message
+	let requestedScope = scope || client.defaultScope || '';
+	const requestedScopes = requestedScope.split(' ');
+	const validScopes = client.validScopes.split(' ');
+	const isValid = !requestedScope || requestedScopes.every(function(key) {
+		return validScopes.indexOf(key) !== -1;
+	});
 
-  if (user.allowedScopes) {
-    var userAllowedScopes = user.allowedScopes.split(' ');
-    var userScopes = validScopes.filter(function(key) {
-      return (!scope || requestedScopes.indexOf(key) !== -1) && userAllowedScopes.indexOf(key) !== -1;
-    });
-    requestedScope = userScopes.join(' ');
-  }
+	if (user.allowedScopes) {
+		const userAllowedScopes = user.allowedScopes.split(' ');
+		const userScopes = validScopes.filter(function(key) {
+			return (!scope || requestedScopes.indexOf(key) !== -1) && userAllowedScopes.indexOf(key) !== -1;
+		});
+		requestedScope = userScopes.join(' ');
+	}
 
-  return callback(false, requestedScope, isValid ? false : 'Invalid scope request');
+	return callback(false, requestedScope, isValid ? false : 'Invalid scope request');
 };
 
 /*
  * Required to support password grant type
  */
 model.getUser = function (username, password, callback) {
-  pg.connect(connString, function (err, client, done) {
-    if (err) return callback(err);
-    client.query('SELECT id, allowed_scopes AS allowedScopes FROM users WHERE username = $1 AND password = $2', [username,
-        password], function (err, result) {
-      callback(err, result.rowCount ? result.rows[0] : false);
-      done();
-    });
-  });
+	pg.connect(connString, function (err, client, done) {
+		if (err) {
+			return callback(err);
+		}
+		client.query('SELECT id, allowed_scopes AS allowedScopes FROM users WHERE username = $1 AND password = $2', [username,
+			password], function (err, result) {
+			callback(err, result.rowCount ? result.rows[0] : false);
+			done();
+		});
+	});
 };

--- a/examples/redis/index.js
+++ b/examples/redis/index.js
@@ -1,30 +1,30 @@
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  oauthserver = require('../../'); // Would be: 'oauth2-server'
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	oauthserver = require('../../'); // Would be: 'oauth2-server'
 
-var app = express();
+const app = express();
 
 app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use(bodyParser.json());
 
 app.oauth = oauthserver({
-  model: require('./model'),
-  grants: ['password', 'refresh_token'],
-  debug: true
+	model: require('./model'),
+	grants: ['password', 'refresh_token'],
+	debug: true
 });
 
 // Handle token grant requests
 app.all('/oauth/token', app.oauth.grant());
 
 app.get('/secret', app.oauth.authorise(), function (req, res) {
-  // Will require a valid access_token
-  res.send('Secret area');
+	// Will require a valid access_token
+	res.send('Secret area');
 });
 
 app.get('/public', function (req, res) {
-  // Does not require an access_token
-  res.send('Public area');
+	// Does not require an access_token
+	res.send('Public area');
 });
 
 // Error handling

--- a/examples/redis/model.js
+++ b/examples/redis/model.js
@@ -1,90 +1,106 @@
-var model = module.exports,
-  util = require('util'),
-  redis = require('redis');
+const model = module.exports,
+	util = require('util'),
+	redis = require('redis');
 
-var db = redis.createClient();
+const db = redis.createClient();
 
-var keys = {
-  token: 'tokens:%s',
-  client: 'clients:%s',
-  refreshToken: 'refresh_tokens:%s',
-  grantTypes: 'clients:%s:grant_types',
-  user: 'users:%s'
+const keys = {
+	token: 'tokens:%s',
+	client: 'clients:%s',
+	refreshToken: 'refresh_tokens:%s',
+	grantTypes: 'clients:%s:grant_types',
+	user: 'users:%s'
 };
 
 model.getAccessToken = function (bearerToken, callback) {
-  db.hgetall(util.format(keys.token, bearerToken), function (err, token) {
-    if (err) return callback(err);
+	db.hgetall(util.format(keys.token, bearerToken), function (err, token) {
+		if (err) {
+			return callback(err);
+		}
 
-    if (!token) return callback();
+		if (!token) {
+			return callback();
+		}
 
-    callback(null, {
-      accessToken: token.accessToken,
-      clientId: token.clientId,
-      expires: token.expires ? new Date(token.expires) : null,
-      userId: token.userId
-    });
-  });
+		callback(null, {
+			accessToken: token.accessToken,
+			clientId: token.clientId,
+			expires: token.expires ? new Date(token.expires) : null,
+			userId: token.userId
+		});
+	});
 };
 
 model.getClient = function (clientId, clientSecret, callback) {
-  db.hgetall(util.format(keys.client, clientId), function (err, client) {
-    if (err) return callback(err);
+	db.hgetall(util.format(keys.client, clientId), function (err, client) {
+		if (err) {
+			return callback(err);
+		}
 
-    if (!client || client.clientSecret !== clientSecret) return callback();
+		if (!client || client.clientSecret !== clientSecret) {
+			return callback();
+		}
 
-    callback(null, {
-      clientId: client.clientId,
-      clientSecret: client.clientSecret
-    });
-  });
+		callback(null, {
+			clientId: client.clientId,
+			clientSecret: client.clientSecret
+		});
+	});
 };
 
 model.getRefreshToken = function (bearerToken, callback) {
-  db.hgetall(util.format(keys.refreshToken, bearerToken), function (err, token) {
-    if (err) return callback(err);
+	db.hgetall(util.format(keys.refreshToken, bearerToken), function (err, token) {
+		if (err) {
+			return callback(err);
+		}
 
-    if (!token) return callback();
+		if (!token) {
+			return callback();
+		}
 
-    callback(null, {
-      refreshToken: token.accessToken,
-      clientId: token.clientId,
-      expires: token.expires ? new Date(token.expires) : null,
-      userId: token.userId
-    });
-  });
+		callback(null, {
+			refreshToken: token.accessToken,
+			clientId: token.clientId,
+			expires: token.expires ? new Date(token.expires) : null,
+			userId: token.userId
+		});
+	});
 };
 
 model.grantTypeAllowed = function (clientId, grantType, callback) {
-  db.sismember(util.format(keys.grantTypes, clientId), grantType, callback);
+	db.sismember(util.format(keys.grantTypes, clientId), grantType, callback);
 };
 
 model.saveAccessToken = function (accessToken, clientId, expires, user, callback) {
-  db.hmset(util.format(keys.token, accessToken), {
-    accessToken: accessToken,
-    clientId: clientId,
-    expires: expires ? expires.toISOString() : null,
-    userId: user.id
-  }, callback);
+	db.hmset(util.format(keys.token, accessToken), {
+		accessToken: accessToken,
+		clientId: clientId,
+		expires: expires ? expires.toISOString() : null,
+		userId: user.id
+	}, callback);
 };
 
 model.saveRefreshToken = function (refreshToken, clientId, expires, user, callback) {
-  db.hmset(util.format(keys.refreshToken, refreshToken), {
-    refreshToken: refreshToken,
-    clientId: clientId,
-    expires: expires ? expires.toISOString() : null,
-    userId: user.id
-  }, callback);
+	db.hmset(util.format(keys.refreshToken, refreshToken), {
+		refreshToken: refreshToken,
+		clientId: clientId,
+		expires: expires ? expires.toISOString() : null,
+		userId: user.id
+	}, callback);
 };
 
 model.getUser = function (username, password, callback) {
-  db.hgetall(util.format(keys.user, username), function (err, user) {
-    if (err) return callback(err);
+	db.hgetall(util.format(keys.user, username), function (err, user) {
+		if (err) {
+			return callback(err);
+		}
 
-    if (!user || password !== user.password) return callback();
+		if (!user || password !== user.password) {
+			return callback();
+		}
 
-    callback(null, {
-      id: username
-    });
-  });
+		callback(null, {
+			id: username
+		});
+	});
 };

--- a/examples/redis/testData.js
+++ b/examples/redis/testData.js
@@ -1,27 +1,27 @@
 #! /usr/bin/env node
 
-var db = require('redis').createClient();
+const db = require('redis').createClient();
 
 db.multi()
-  .hmset('users:username', {
-    id: 'username',
-    username: 'username',
-    password: 'password'
-  })
-  .hmset('clients:client', {
-    clientId: 'client',
-    clientSecret: 'secret'
-  })
-  .sadd('clients:client:grant_types', [
-    'password',
-    'refresh_token'
-  ])
-  .exec(function (errs) {
-    if (errs) {
-      console.error(errs[0].message);
-      return process.exit(1);
-    }
+	.hmset('users:username', {
+		id: 'username',
+		username: 'username',
+		password: 'password'
+	})
+	.hmset('clients:client', {
+		clientId: 'client',
+		clientSecret: 'secret'
+	})
+	.sadd('clients:client:grant_types', [
+		'password',
+		'refresh_token'
+	])
+	.exec(function (errs) {
+		if (errs) {
+			console.error(errs[0].message);
+			return process.exit(1);
+		}
 
-    console.log('Client and user added successfully');
-    process.exit();
-  });
+		console.log('Client and user added successfully');
+		process.exit();
+	});

--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var error = require('./error'),
-  runner = require('./runner'),
-  token = require('./token');
+const error = require('./error'),
+	runner = require('./runner'),
+	token = require('./token');
 
 module.exports = AuthCodeGrant;
 
@@ -25,13 +26,13 @@ module.exports = AuthCodeGrant;
  *
  * @type {Array}
  */
-var fns = [
-  checkParams,
-  checkClient,
-  checkUserApproved,
-  generateCode,
-  saveAuthCode,
-  redirect
+const fns = [
+	checkParams,
+	checkClient,
+	checkUserApproved,
+	generateCode,
+	saveAuthCode,
+	redirect
 ];
 
 /**
@@ -43,24 +44,23 @@ var fns = [
  * @param {Function} next
  */
 function AuthCodeGrant(config, req, res, next, check) {
-  this.config = config;
-  this.model = config.model;
-  this.req = req;
-  this.res = res;
-  this.check = check;
+	this.config = config;
+	this.model = config.model;
+	this.req = req;
+	this.res = res;
+	this.check = check;
 
-  var self = this;
-  runner(fns, this, function (err) {
-    if (err && res.oauthRedirect) {
-      // Custom redirect error handler
-      res.redirect(self.client.redirectUri + '?error=' + err.error +
+	runner(fns, this, (err) => {
+		if (err && res.oauthRedirect) {
+			// Custom redirect error handler
+			res.redirect(this.client.redirectUri + '?error=' + err.error +
         '&error_description=' + err.error_description + '&code=' + err.code);
 
-      return self.config.continueAfterResponse ? next() : null;
-    }
+			return this.config.continueAfterResponse ? next() : null;
+		}
 
-    next(err);
-  });
+		next(err);
+	});
 }
 
 /**
@@ -70,32 +70,34 @@ function AuthCodeGrant(config, req, res, next, check) {
  * @this   OAuth
  */
 function checkParams (done) {
-  var body = this.req.body;
-  var query = this.req.query;
-  if (!body && !query) return done(error('invalid_request'));
+	const body = this.req.body;
+	const query = this.req.query;
+	if (!body && !query) {
+		return done(error('invalid_request'));
+	}
 
-  // Response type
-  this.responseType = body.response_type || query.response_type;
-  if (this.responseType !== 'code') {
-    return done(error('invalid_request',
-      'Invalid response_type parameter (must be "code")'));
-  }
+	// Response type
+	this.responseType = body.response_type || query.response_type;
+	if (this.responseType !== 'code') {
+		return done(error('invalid_request',
+			'Invalid response_type parameter (must be "code")'));
+	}
 
-  // Client
-  this.clientId = body.client_id || query.client_id;
-  if (!this.clientId) {
-    return done(error('invalid_request',
-      'Invalid or missing client_id parameter'));
-  }
+	// Client
+	this.clientId = body.client_id || query.client_id;
+	if (!this.clientId) {
+		return done(error('invalid_request',
+			'Invalid or missing client_id parameter'));
+	}
 
-  // Redirect URI
-  this.redirectUri = body.redirect_uri || query.redirect_uri;
-  if (!this.redirectUri) {
-    return done(error('invalid_request',
-      'Invalid or missing redirect_uri parameter'));
-  }
+	// Redirect URI
+	this.redirectUri = body.redirect_uri || query.redirect_uri;
+	if (!this.redirectUri) {
+		return done(error('invalid_request',
+			'Invalid or missing redirect_uri parameter'));
+	}
 
-  done();
+	done();
 }
 
 /**
@@ -105,28 +107,29 @@ function checkParams (done) {
  * @this   OAuth
  */
 function checkClient (done) {
-  var self = this;
-  this.model.getClient(this.clientId, null, function (err, client) {
-    if (err) return done(error('server_error', false, err));
+	this.model.getClient(this.clientId, null, (err, client) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!client) {
-      return done(error('invalid_client', 'Invalid client credentials'));
-    } else if (Array.isArray(client.redirectUri)) {
-      if (client.redirectUri.indexOf(self.redirectUri) === -1) {
-        return done(error('invalid_request', 'redirect_uri does not match'));
-      }
-      client.redirectUri = self.redirectUri;
-    } else if (client.redirectUri !== self.redirectUri) {
-      return done(error('invalid_request', 'redirect_uri does not match'));
-    }
+		if (!client) {
+			return done(error('invalid_client', 'Invalid client credentials'));
+		} else if (Array.isArray(client.redirectUri)) {
+			if (client.redirectUri.indexOf(this.redirectUri) === -1) {
+				return done(error('invalid_request', 'redirect_uri does not match'));
+			}
+			client.redirectUri = this.redirectUri;
+		} else if (client.redirectUri !== this.redirectUri) {
+			return done(error('invalid_request', 'redirect_uri does not match'));
+		}
 
-    // The request contains valid params so any errors after this point
-    // are redirected to the redirect_uri
-    self.res.oauthRedirect = true;
-    self.client = client;
+		// The request contains valid params so any errors after this point
+		// are redirected to the redirect_uri
+		this.res.oauthRedirect = true;
+		this.client = client;
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -136,20 +139,21 @@ function checkClient (done) {
  * @this   OAuth
  */
 function checkUserApproved (done) {
-  var self = this;
-  this.check(this.req, this.client, function (err, allowed, user, scope) {
-    if (err) return done(error('server_error', false, err));
+	this.check(this.req, this.client, (err, allowed, user, scope) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!allowed) {
-      return done(error('access_denied',
-        'The user denied access to your application'));
-    }
+		if (!allowed) {
+			return done(error('access_denied',
+				'The user denied access to your application'));
+		}
 
-    self.user = user;
-    self.scope = scope;
+		this.user = user;
+		this.scope = scope;
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -159,11 +163,10 @@ function checkUserApproved (done) {
  * @this   OAuth
  */
 function generateCode (done) {
-  var self = this;
-  token(this, 'authorization_code', function (err, code) {
-    self.authCode = code;
-    done(err);
-  });
+	token(this, 'authorization_code', (err, code) => {
+		this.authCode = code;
+		done(err);
+	});
 }
 
 /**
@@ -173,14 +176,15 @@ function generateCode (done) {
  * @this   OAuth
  */
 function saveAuthCode (done) {
-  var expires = new Date();
-  expires.setSeconds(expires.getSeconds() + this.config.authCodeLifetime);
+	const expires = new Date();
+	expires.setSeconds(expires.getSeconds() + this.config.authCodeLifetime);
 
-  this.model.saveAuthCode(this.authCode, this.client.clientId, expires,
-      this.user, this.scope, function (err) {
-    if (err) return done(error('server_error', false, err));
-    done();
-  });
+	this.model.saveAuthCode(this.authCode, this.client.clientId, expires, this.user, this.scope, (err) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
+		done();
+	});
 }
 
 /**
@@ -190,9 +194,10 @@ function saveAuthCode (done) {
  * @this   OAuth
  */
 function redirect (done) {
-  this.res.redirect(this.client.redirectUri + '?code=' + this.authCode +
+	this.res.redirect(this.client.redirectUri + '?code=' + this.authCode +
       (this.req.query.state ? '&state=' + this.req.query.state : ''));
 
-  if (this.config.continueAfterResponse)
-    return done();
+	if (this.config.continueAfterResponse) {
+		return done();
+	}
 }

--- a/lib/authorise.js
+++ b/lib/authorise.js
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var error = require('./error'),
-  runner = require('./runner'),
-  Client = require('./client');
+const error = require('./error'),
+	runner = require('./runner'),
+	Client = require('./client');
 
 module.exports = Authorise;
 
@@ -25,10 +26,10 @@ module.exports = Authorise;
  *
  * @type {Array}
  */
-var fns = [
-  checkAuthoriseType,
-  checkScope,
-  checkForQueryAccessToken
+const fns = [
+	checkAuthoriseType,
+	checkScope,
+	checkForQueryAccessToken
 ];
 
 /**
@@ -40,100 +41,105 @@ var fns = [
  * @param {Object}   options
  * @param {Function} next
  */
-function Authorise (config, req, res, options, next) {
-  options = options || {};
+function Authorise(config, req, res, options, next) {
+	options = options || {};
 
-  this.config = config;
-  this.model = config.model;
-  this.req = req;
-  this.res = res;
-  this.options = options;
+	this.config = config;
+	this.model = config.model;
+	this.req = req;
+	this.res = res;
+	this.options = options;
 
-  runner(fns, this, next);
+	runner(fns, this, next);
 }
 
 function checkAuthoriseType(done) {
-  var client = Client.credsFromBasic(this.req) || Client.credsFromBody(this.req);
-  if (this.options.implicit) {
-    if (this.req.body.response_type === 'token') {
-      if (client.clientId) {
-        this.redirectUri = this.req.body.redirect_uri || this.req.query.redirect_uri;
-        this.clientId = client.clientId;
-        this.req.auth_type = 'implicit';
-        return checkImplicitClient.call(this, done);
-      }
-    }
-  }
+	const client = Client.credsFromBasic(this.req) || Client.credsFromBody(this.req);
+	if (this.options.implicit) {
+		if (this.req.body.response_type === 'token') {
+			if (client.clientId) {
+				this.redirectUri = this.req.body.redirect_uri || this.req.query.redirect_uri;
+				this.clientId = client.clientId;
+				this.req.auth_type = 'implicit';
+				return checkImplicitClient.call(this, done);
+			}
+		}
+	}
 
-  if (this.options.client_credentials) {
-    if (client.clientId && client.clientSecret) {
-      this.client = client;
-      this.req.auth_type = 'client_credentials';
-      return getUserFromClient.call(this, done);
-    }
-  }
+	if (this.options.client_credentials) {
+		if (client.clientId && client.clientSecret) {
+			this.client = client;
+			this.req.auth_type = 'client_credentials';
+			return getUserFromClient.call(this, done);
+		}
+	}
 
-  getBearerToken.call(this, done);
+	getBearerToken.call(this, done);
 }
 
 function getUserFromClient(done) {
-  var self = this;
-  this.model.getClient(this.client.clientId, this.client.clientSecret,
-      function (err, client) {
-    if (err) return done(error('server_error', false, err));
+	this.model.getClient(this.client.clientId, this.client.clientSecret, (err, client) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!client) {
-      return done(error('invalid_client', 'Client credentials are invalid'));
-    }
+		if (!client) {
+			return done(error('invalid_client', 'Client credentials are invalid'));
+		}
 
-    self.model.getUserFromClient(client, function (err, user) {
-      if (err) return done(error('server_error', false, err));
+		this.model.getUserFromClient(client, (err, user) => {
+			if (err) {
+				return done(error('server_error', false, err));
+			}
 
-      if (!user) {
-        return done(error('invalid_grant', 'Client credentials are invalid'));
-      }
+			if (!user) {
+				return done(error('invalid_grant', 'Client credentials are invalid'));
+			}
 
-      self.req.oauth = { bearerToken: user, client };
-      self.req.user = { id: user.id };
+			this.req.oauth = { bearerToken: user, client };
+			this.req.user = { id: user.id };
 
-      done();
-    });
-  });
+			done();
+		});
+	});
 }
 
-function checkImplicitClient (done) {
-  var self = this;
-  this.model.getClient(this.clientId, null, function (err, client) {
-    if (err) return done(error('server_error', false, err));
+function checkImplicitClient(done) {
+	this.model.getClient(this.clientId, null, (err, client) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!client) {
-      return done(error('invalid_client', 'Invalid client credentials'));
-    } else if (self.redirectUri && Array.isArray(client.redirectUri)) {
-      if (client.redirectUri.indexOf(self.redirectUri) === -1) {
-        return done(error('invalid_request', 'redirect_uri does not match'));
-      }
-      client.redirectUri = self.redirectUri;
-    } else if (self.redirectUri && client.redirectUri !== self.redirectUri) {
-      return done(error('invalid_request', 'redirect_uri does not match'));
-    }
+		if (!client) {
+			return done(error('invalid_client', 'Invalid client credentials'));
+		} else if (this.redirectUri && Array.isArray(client.redirectUri)) {
+			if (client.redirectUri.indexOf(this.redirectUri) === -1) {
+				return done(error('invalid_request', 'redirect_uri does not match'));
+			}
+			client.redirectUri = this.redirectUri;
+		} else if (this.redirectUri && client.redirectUri !== this.redirectUri) {
+			return done(error('invalid_request', 'redirect_uri does not match'));
+		}
 
-    self.model.getUserFromClient(client, function (err, user) {
-      if (err) return done(error('server_error', false, err));
+		this.model.getUserFromClient(client, (err, user) => {
+			if (err) {
+				return done(error('server_error', false, err));
+			}
 
-      if (!user) {
-        return done(error('invalid_grant', 'Client credentials are invalid'));
-      }
+			if (!user) {
+				return done(error('invalid_grant', 'Client credentials are invalid'));
+			}
 
-      // The request contains valid params so any errors after this point
-      // are redirected to the redirect_uri
-      self.res.redirectUri = client.redirectUri;
-      self.res.oauthRedirect = true;
-      self.req.oauth = { bearerToken: user, client: client };
-      self.req.user = { id: user.id };
+			// The request contains valid params so any errors after this point
+			// are redirected to the redirect_uri
+			this.res.redirectUri = client.redirectUri;
+			this.res.oauthRedirect = true;
+			this.req.oauth = { bearerToken: user, client: client };
+			this.req.user = { id: user.id };
 
-      done();
-    });
-  });
+			done();
+		});
+	});
 }
 
 /**
@@ -144,49 +150,49 @@ function checkImplicitClient (done) {
  * @param  {Function} done
  * @this   Authorise
  */
-function getBearerToken (done) {
-  var headerToken = this.req.get('Authorization'),
-    getToken =  this.req.query.access_token,
-    postToken = this.req.body ? this.req.body.access_token : undefined;
+function getBearerToken(done) {
+	let headerToken = this.req.get('Authorization');
+	const getToken = this.req.query.access_token;
+	const postToken = this.req.body ? this.req.body.access_token : undefined;
 
-  // Check exactly one method was used
-  var methodsUsed = (headerToken !== undefined) + (getToken !== undefined) +
-    (postToken !== undefined);
+	// Check exactly one method was used
+	const methodsUsed = (headerToken !== undefined) + (getToken !== undefined) +
+		(postToken !== undefined);
 
-  if (methodsUsed > 1) {
-    return done(error('invalid_request',
-      'Only one method may be used to authenticate at a time (Auth header,  ' +
-        'GET or POST).'));
-  } else if (methodsUsed === 0) {
-    return done(error('invalid_request', 'The access token was not found'));
-  }
+	if (methodsUsed > 1) {
+		return done(error('invalid_request',
+			'Only one method may be used to authenticate at a time (Auth header,  ' +
+			'GET or POST).'));
+	} else if (methodsUsed === 0) {
+		return done(error('invalid_request', 'The access token was not found'));
+	}
 
-  // Header: http://tools.ietf.org/html/rfc6750#section-2.1
-  if (headerToken) {
-    var matches = headerToken.match(/Bearer\s(\S+)/);
+	// Header: http://tools.ietf.org/html/rfc6750#section-2.1
+	if (headerToken) {
+		const matches = headerToken.match(/Bearer\s(\S+)/);
 
-    if (!matches) {
-      return done(error('invalid_request', 'Malformed auth header'));
-    }
+		if (!matches) {
+			return done(error('invalid_request', 'Malformed auth header'));
+		}
 
-    headerToken = matches[1];
-  }
+		headerToken = matches[1];
+	}
 
-  // POST: http://tools.ietf.org/html/rfc6750#section-2.2
-  if (postToken) {
-    if (this.req.method === 'GET') {
-      return done(error('invalid_request',
-        'Method cannot be GET When putting the token in the body.'));
-    }
+	// POST: http://tools.ietf.org/html/rfc6750#section-2.2
+	if (postToken) {
+		if (this.req.method === 'GET') {
+			return done(error('invalid_request',
+				'Method cannot be GET When putting the token in the body.'));
+		}
 
-    if (!this.req.is('application/x-www-form-urlencoded')) {
-      return done(error('invalid_request', 'When putting the token in the ' +
-        'body, content type must be application/x-www-form-urlencoded.'));
-    }
-  }
+		if (!this.req.is('application/x-www-form-urlencoded')) {
+			return done(error('invalid_request', 'When putting the token in the ' +
+				'body, content type must be application/x-www-form-urlencoded.'));
+		}
+	}
 
-  this.bearerToken = headerToken || postToken || getToken;
-  checkToken.call(this, done);
+	this.bearerToken = headerToken || postToken || getToken;
+	checkToken.call(this, done);
 }
 
 /**
@@ -196,32 +202,33 @@ function getBearerToken (done) {
  * @param  {Function} done
  * @this   Authorise
  */
-function checkToken (done) {
-  var self = this;
-  this.model.getAccessToken(this.bearerToken, function (err, token) {
-    if (err) return done(error('server_error', false, err));
+function checkToken(done) {
+	this.model.getAccessToken(this.bearerToken, (err, token) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!token) {
-      return done(error('invalid_token',
-        'The access token provided is invalid.'));
-    }
+		if (!token) {
+			return done(error('invalid_token',
+				'The access token provided is invalid.'));
+		}
 
-    if (token.expires !== null &&
-      (!token.expires || token.expires < new Date())) {
-      return done(error('invalid_token',
-        'The access token provided has expired.'));
-    }
+		if (token.expires !== null &&
+			(!token.expires || token.expires < new Date())) {
+			return done(error('invalid_token',
+				'The access token provided has expired.'));
+		}
 
-    if (token.is_demo && !['GET', 'HEAD', 'OPTIONS'].includes(self.req.method)) {
-      return done(error('demo_read_only', 'Demo accounts have read-only access'));
-    }
+		if (token.is_demo && !['GET', 'HEAD', 'OPTIONS'].includes(this.req.method)) {
+			return done(error('demo_read_only', 'Demo accounts have read-only access'));
+		}
 
-    // Expose params
-    self.req.oauth = { bearerToken: token };
-    self.req.user = token.user ? token.user : { id: token.userId };
+		// Expose params
+		this.req.oauth = { bearerToken: token };
+		this.req.user = token.user ? token.user : { id: token.userId };
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -230,16 +237,21 @@ function checkToken (done) {
  * @param {Function} done
  * @this  Authorise
  */
-function checkScope (done) {
-  if (!this.model.authoriseScope) return done();
+function checkScope(done) {
+	if (!this.model.authoriseScope) {
+		return done();
+	}
 
-  this.model.authoriseScope(this.req.oauth.bearerToken, this.options.scope,
-      function (err, invalid) {
-    if (err) return done(error('server_error', false, err));
-    if (invalid) return done(error('invalid_scope', invalid));
+	this.model.authoriseScope(this.req.oauth.bearerToken, this.options.scope, (err, invalid) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
+		if (invalid) {
+			return done(error('invalid_scope', invalid));
+		}
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -248,15 +260,15 @@ function checkScope (done) {
  * @this Authorise
  */
 function checkForQueryAccessToken(done) {
-  // If no access_token and no provided model method, continue
-  if (!this.req.query.access_token || !this.model.shouldAllowQueryAccessToken) {
-    return done();
-  }
+	// If no access_token and no provided model method, continue
+	if (!this.req.query.access_token || !this.model.shouldAllowQueryAccessToken) {
+		return done();
+	}
 
-  this.model.shouldAllowQueryAccessToken(this.req, (errorMessage) => {
-    if (!errorMessage) {
-      return done();
-    }
-    return done(error('invalid_request', errorMessage));
-  });
+	this.model.shouldAllowQueryAccessToken(this.req, (errorMessage) => {
+		if (!errorMessage) {
+			return done();
+		}
+		return done(error('invalid_request', errorMessage));
+	});
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var auth = require('basic-auth');
+const auth = require('basic-auth');
 
 /**
  * Client Object (internal use only)
@@ -9,8 +9,8 @@ var auth = require('basic-auth');
  * @param {String} secret client_secret
  */
 function Client (id, secret) {
-  this.clientId = id;
-  this.clientSecret = secret;
+	this.clientId = id;
+	this.clientSecret = secret;
 }
 
 /**
@@ -19,11 +19,13 @@ function Client (id, secret) {
  * @return {Object} Client
  */
 function credsFromBasic (req) {
-  var user = auth(req);
+	const user = auth(req);
 
-  if (!user) return false;
+	if (!user) {
+		return false;
+	}
 
-  return new Client(user.name, user.pass);
+	return new Client(user.name, user.pass);
 }
 
 /**
@@ -32,7 +34,7 @@ function credsFromBasic (req) {
  * @return {Object} Client
  */
 function credsFromBody (req) {
-  return new Client(req.body.client_id, req.body.client_secret);
+	return new Client(req.body.client_id, req.body.client_secret);
 }
 
 module.exports = Client;

--- a/lib/error.js
+++ b/lib/error.js
@@ -13,75 +13,77 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var util = require('util');
+const util = require('util');
 
 module.exports = OAuth2Error;
 
 /**
  * Error
  *
- * @param {String} error       Error type, determines status code, see below
- * @param {String} description Full error description
+ * @param {string} error       Error type, determines status code, see below
+ * @param {string | null} description Full error description
  * @param {Error}  [err]       Original error
  */
 function OAuth2Error (error, description, err) {
-  if (!(this instanceof OAuth2Error))
-    return new OAuth2Error(error, description, err);
+	if (!(this instanceof OAuth2Error)) {
+		return new OAuth2Error(error, description, err);
+	}
 
-  Error.call(this);
+	Error.call(this);
 
-  this.name = this.constructor.name;
-  if (err instanceof Error) {
-    this.message = err.message;
-    this.stack = err.stack;
-  } else {
-    this.message = description;
-    Error.captureStackTrace(this, this.constructor);
-  }
+	this.name = this.constructor.name;
+	if (err instanceof Error) {
+		this.message = err.message;
+		this.stack = err.stack;
+	} else {
+		this.message = description;
+		Error.captureStackTrace(this, this.constructor);
+	}
 
-  this.headers = {
-    'Cache-Control': 'no-store',
-    'Pragma': 'no-cache'
-  };
+	this.headers = {
+		'Cache-Control': 'no-store',
+		'Pragma': 'no-cache'
+	};
 
-  switch (error) {
-    case 'invalid_client':
-      this.headers['WWW-Authenticate'] = 'Basic realm="Service"';
-      /* falls through */
-    case 'invalid_scope':
-      if (typeof this.message === 'boolean') {
-        this.message = 'Invalid scope';
-      }
-    // eslint-disable-next-line no-fallthrough
-    case 'invalid_grant':
-    case 'invalid_request':
-      this.code = 400;
-      break;
-    case 'invalid_token':
-      this.code = 401;
-      break;
-    case 'sso_user':
-    case 'demo_read_only':
-      this.code = 403;
-      break;
-    case 'mfa_required':
-      this.code = 403;
-      this.mfa_token = description;
-      description = 'Multi-factor authentication required';
-      break;
-    case 'rate_limit_exceeded':
-      this.code = 429;
-      break;
-    case 'server_error':
-      this.code = 503;
-      break;
-    default:
-      this.code = 500;
-  }
+	switch (error) {
+		case 'invalid_client':
+			this.headers['WWW-Authenticate'] = 'Basic realm="Service"';
+			/* falls through */
+		case 'invalid_scope':
+			if (typeof this.message === 'boolean') {
+				this.message = 'Invalid scope';
+			}
+			// eslint-disable-next-line no-fallthrough
+		case 'invalid_grant':
+		case 'invalid_request':
+			this.code = 400;
+			break;
+		case 'invalid_token':
+			this.code = 401;
+			break;
+		case 'sso_user':
+		case 'demo_read_only':
+			this.code = 403;
+			break;
+		case 'mfa_required':
+			this.code = 403;
+			this.mfa_token = description;
+			description = 'Multi-factor authentication required';
+			break;
+		case 'rate_limit_exceeded':
+			this.code = 429;
+			break;
+		case 'server_error':
+			this.code = 503;
+			break;
+		default:
+			this.code = 500;
+	}
 
-  this.error = error;
-  this.error_description = description || error;
+	this.error = error;
+	this.error_description = description || error;
 }
 
 util.inherits(OAuth2Error, Error);

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var Client = require('./client'),
-  error = require('./error'),
-  runner = require('./runner'),
-  token = require('./token');
+const Client = require('./client'),
+	error = require('./error'),
+	runner = require('./runner'),
+	token = require('./token');
 
 module.exports = Grant;
 
@@ -26,21 +27,21 @@ module.exports = Grant;
  *
  * @type {Array}
  */
-var fns = [
-  extractCredentials,
-  checkClient,
-  checkGrantTypeAllowed,
-  checkGrantType,
-  checkScope,
-  exposeUser,
-  checkMfa,
-  generateAccessToken,
-  generateExpiresTime,
-  saveAccessToken,
-  generateRefreshToken,
-  generateRefreshExpiresTime,
-  saveRefreshToken,
-  sendResponse
+const fns = [
+	extractCredentials,
+	checkClient,
+	checkGrantTypeAllowed,
+	checkGrantType,
+	checkScope,
+	exposeUser,
+	checkMfa,
+	generateAccessToken,
+	generateExpiresTime,
+	saveAccessToken,
+	generateRefreshToken,
+	generateRefreshExpiresTime,
+	saveRefreshToken,
+	sendResponse
 ];
 
 /**
@@ -51,15 +52,15 @@ var fns = [
  * @param {Object}   res
  * @param {Function} next
  */
-function Grant (config, options, req, res, next) {
-  this.config = config;
-  this.options = options || {};
-  this.model = config.model;
-  this.now = new Date();
-  this.req = req;
-  this.res = res;
+function Grant(config, options, req, res, next) {
+	this.config = config;
+	this.options = options || {};
+	this.model = config.model;
+	this.now = new Date();
+	this.req = req;
+	this.res = res;
 
-  runner(fns, this, next);
+	runner(fns, this, next);
 }
 
 /**
@@ -68,33 +69,28 @@ function Grant (config, options, req, res, next) {
  * @param  {Function} done
  * @this   OAuth
  */
-function extractCredentials (done) {
-  // Only POST via application/x-www-form-urlencoded is acceptable
-  if (this.req.method !== 'POST' ||
-      !this.req.is('application/x-www-form-urlencoded')) {
-    return done(error('invalid_request',
-      'Method must be POST with application/x-www-form-urlencoded encoding'));
-  }
+function extractCredentials(done) {
+	// Only POST via application/x-www-form-urlencoded is acceptable
+	if (this.req.method !== 'POST' || !this.req.is('application/x-www-form-urlencoded')) {
+		return done(error('invalid_request', 'Method must be POST with application/x-www-form-urlencoded encoding'));
+	}
 
-  // Grant type
-  this.grantType = this.req.body && this.req.body.grant_type;
-  if (!this.grantType || typeof this.grantType !== 'string' || !this.grantType.match(this.config.regex.grantType)) {
-    return done(error('invalid_request',
-      'Invalid or missing grant_type parameter'));
-  }
+	// Grant type
+	this.grantType = this.req.body && this.req.body.grant_type;
+	if (!this.grantType || typeof this.grantType !== 'string' || !this.grantType.match(this.config.regex.grantType)) {
+		return done(error('invalid_request', 'Invalid or missing grant_type parameter'));
+	}
 
-  // Extract credentials
-  // http://tools.ietf.org/html/rfc6749#section-3.2.1
-  this.client = Client.credsFromBasic(this.req) || Client.credsFromBody(this.req);
-  if (!this.client.clientId ||
-      !this.client.clientId.match(this.config.regex.clientId)) {
-    return done(error('invalid_client',
-      'Invalid or missing client_id parameter'));
-  } else if (!this.client.clientSecret) {
-    return done(error('invalid_client', 'Missing client_secret parameter'));
-  }
+	// Extract credentials
+	// http://tools.ietf.org/html/rfc6749#section-3.2.1
+	this.client = Client.credsFromBasic(this.req) || Client.credsFromBody(this.req);
+	if (!this.client.clientId || !this.client.clientId.match(this.config.regex.clientId)) {
+		return done(error('invalid_client', 'Invalid or missing client_id parameter'));
+	} else if (!this.client.clientSecret) {
+		return done(error('invalid_client', 'Missing client_secret parameter'));
+	}
 
-  done();
+	done();
 }
 
 
@@ -104,26 +100,25 @@ function extractCredentials (done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function checkClient (done) {
-  var self = this;
+function checkClient(done) {
+	this.model.getClient(this.client.clientId, this.client.clientSecret, (err, client) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-  this.model.getClient(this.client.clientId, this.client.clientSecret,
-      function (err, client) {
-    if (err) return done(error('server_error', false, err));
+		if (!client) {
+			return done(error('invalid_client', 'Client credentials are invalid'));
+		}
 
-    if (!client) {
-      return done(error('invalid_client', 'Client credentials are invalid'));
-    }
+		this.req.oauth = { client: client };
 
-    self.req.oauth = { client: client };
+		// preserve secret, but use everything else from this method
+		const secret = this.client.clientSecret;
+		this.client = client;
+		this.client.clientSecret = secret;
 
-    // preserve secret, but use everything else from this method
-    var secret = self.client.clientSecret;
-    self.client = client;
-    self.client.clientSecret = secret;
-
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -132,31 +127,29 @@ function checkClient (done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function checkGrantType (done) {
-  if (this.grantType.match(/^[a-zA-Z][a-zA-Z0-9+.-]+:/)
-      && this.model.extendedGrant) {
-    return useExtendedGrant.call(this, done);
-  }
+function checkGrantType(done) {
+	if (this.grantType.match(/^[a-zA-Z][a-zA-Z0-9+.-]+:/) && this.model.extendedGrant) {
+		return useExtendedGrant.call(this, done);
+	}
 
-  switch (this.grantType) {
-    case 'authorization_code':
-      return useAuthCodeGrant.call(this, done);
-    case 'password':
-      return usePasswordGrant.call(this, done);
-    case 'refresh_token':
-      return useRefreshTokenGrant.call(this, done);
-    case 'client_credentials':
-      return useClientCredentialsGrant.call(this, done);
-    case 'urn:custom:mfa-otp':
-      return useMfaOtpGrant.call(this, done);
-    case 'urn:custom:recovery-code':
-      return useRecoveryCodeGrant.call(this, done);
-    case 'urn:custom:demo_account':
-      return useDemoAccountGrant.call(this, done);
-    default:
-      done(error('invalid_request',
-        'Invalid grant_type parameter or parameter missing'));
-  }
+	switch (this.grantType) {
+		case 'authorization_code':
+			return useAuthCodeGrant.call(this, done);
+		case 'password':
+			return usePasswordGrant.call(this, done);
+		case 'refresh_token':
+			return useRefreshTokenGrant.call(this, done);
+		case 'client_credentials':
+			return useClientCredentialsGrant.call(this, done);
+		case 'urn:custom:mfa-otp':
+			return useMfaOtpGrant.call(this, done);
+		case 'urn:custom:recovery-code':
+			return useRecoveryCodeGrant.call(this, done);
+		case 'urn:custom:demo_account':
+			return useDemoAccountGrant.call(this, done);
+		default:
+			done(error('invalid_request', 'Invalid grant_type parameter or parameter missing'));
+	}
 }
 
 /**
@@ -164,33 +157,33 @@ function checkGrantType (done) {
  *
  * @param  {Function} done
  */
-function useAuthCodeGrant (done) {
-  var code = this.req.body.code;
+function useAuthCodeGrant(done) {
+	const code = this.req.body.code;
 
-  if (!code) {
-    return done(error('invalid_request', 'No "code" parameter'));
-  }
+	if (!code) {
+		return done(error('invalid_request', 'No "code" parameter'));
+	}
 
-  var self = this;
-  this.model.getAuthCode(code, function (err, authCode) {
-    if (err) return done(error('server_error', false, err));
+	this.model.getAuthCode(code, (err, authCode) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!authCode || authCode.clientId !== self.client.clientId) {
-      return done(error('invalid_grant', 'Invalid code'));
-    } else if (authCode.expires < self.now) {
-      return done(error('invalid_grant', 'Code has expired'));
-    }
+		if (!authCode || authCode.clientId !== this.client.clientId) {
+			return done(error('invalid_grant', 'Invalid code'));
+		} else if (authCode.expires < this.now) {
+			return done(error('invalid_grant', 'Code has expired'));
+		}
 
-    self.user = authCode.user || { id: authCode.userId };
-    self.scope = authCode.scope;
+		this.user = authCode.user || { id: authCode.userId };
+		this.scope = authCode.scope;
 
-    if (!self.user.id) {
-      return done(error('server_error', false,
-        'No user/userId parameter returned from getauthCode'));
-    }
+		if (!this.user.id) {
+			return done(error('server_error', false, 'No user/userId parameter returned from getauthCode'));
+		}
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -198,32 +191,32 @@ function useAuthCodeGrant (done) {
  *
  * @param  {Function} done
  */
-function usePasswordGrant (done) {
-  // User credentials
-  var uname = this.req.body.username,
-    pword = this.req.body.password;
-  if (!uname || !pword) {
-    return done(error('invalid_client',
-      'Missing parameters. "username" and "password" are required'));
-  }
+function usePasswordGrant(done) {
+	// User credentials
+	const uname = this.req.body.username,
+		pword = this.req.body.password;
+	if (!uname || !pword) {
+		return done(error('invalid_client', 'Missing parameters. "username" and "password" are required'));
+	}
 
-  var self = this;
-  return self.model.checkSSOUser(uname, this.req)
-  .then(function () {
-    return self.model.getUser(uname, pword, function (err, user) {
-      if (err) return done(error('server_error', false, err));
-      if (!user) {
-        return done(error('invalid_grant', 'User credentials are invalid'));
-      }
+	return this.model.checkSSOUser(uname, this.req)
+		.then(() => {
+			return this.model.getUser(uname, pword, (err, user) => {
+				if (err) {
+					return done(error('server_error', false, err));
+				}
+				if (!user) {
+					return done(error('invalid_grant', 'User credentials are invalid'));
+				}
 
-      self.user = user;
-      self.scope = self.req.body.scope;
+				this.user = user;
+				this.scope = this.req.body.scope;
 
-      done();
-    }, self.req);
-  }).catch(function (err) {
-    return done(error('sso_user', err));
-  });
+				done();
+			}, this.req);
+		}).catch((err) => {
+			return done(error('sso_user', err));
+		});
 }
 
 /**
@@ -231,42 +224,45 @@ function usePasswordGrant (done) {
  *
  * @param  {Function} done
  */
-function useRefreshTokenGrant (done) {
-  var token = this.req.body.refresh_token;
+function useRefreshTokenGrant(done) {
+	const token = this.req.body.refresh_token;
 
-  if (!token) {
-    return done(error('invalid_request', 'No "refresh_token" parameter'));
-  }
+	if (!token) {
+		return done(error('invalid_request', 'No "refresh_token" parameter'));
+	}
 
-  var self = this;
-  this.model.getRefreshToken(token, function (err, refreshToken) {
-    if (err) return done(error('server_error', false, err));
+	this.model.getRefreshToken(token, (err, refreshToken) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!refreshToken || refreshToken.clientId !== self.client.clientId) {
-      return done(error('invalid_grant', 'Invalid refresh token'));
-    } else if (refreshToken.expires !== null &&
-        refreshToken.expires < self.now) {
-      return done(error('invalid_grant', 'Refresh token has expired'));
-    }
+		if (!refreshToken || refreshToken.clientId !== this.client.clientId) {
+			return done(error('invalid_grant', 'Invalid refresh token'));
+		} else if (refreshToken.expires !== null &&
+			refreshToken.expires < this.now) {
+			return done(error('invalid_grant', 'Refresh token has expired'));
+		}
 
-    if (!refreshToken.user && !refreshToken.userId) {
-      return done(error('server_error', false,
-        'No user/userId parameter returned from getRefreshToken'));
-    }
+		if (!refreshToken.user && !refreshToken.userId) {
+			// TODO How was this expected to work?? The function doesn't take these args as is
+			return done(error('server_error', false, 'No user/userId parameter returned from getRefreshToken'));
+		}
 
-    // isCustomer will be looked at in model.saveAccessToken to be added to the new token
-    self.user = refreshToken.user || { id: refreshToken.userId, isCustomer: refreshToken.isCustomer };
-    self.scope = refreshToken.scope;
+		// isCustomer will be looked at in model.saveAccessToken to be added to the new token
+		this.user = refreshToken.user || { id: refreshToken.userId, isCustomer: refreshToken.isCustomer };
+		this.scope = refreshToken.scope;
 
-    if (self.model.revokeRefreshToken) {
-      return self.model.revokeRefreshToken(token, function (err) {
-        if (err) return done(error('server_error', false, err));
-        done();
-      });
-    }
+		if (this.model.revokeRefreshToken) {
+			return this.model.revokeRefreshToken(token, (err) => {
+				if (err) {
+					return done(error('server_error', false, err));
+				}
+				done();
+			});
+		}
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -274,29 +270,29 @@ function useRefreshTokenGrant (done) {
  *
  * @param  {Function} done
  */
-function useClientCredentialsGrant (done) {
-  // Client credentials
-  var clientId = this.client.clientId,
-    clientSecret = this.client.clientSecret;
+function useClientCredentialsGrant(done) {
+	// Client credentials
+	const clientId = this.client.clientId,
+		clientSecret = this.client.clientSecret;
 
-  if (!clientId || !clientSecret) {
-    return done(error('invalid_client',
-      'Missing parameters. "client_id" and "client_secret" are required'));
-  }
+	if (!clientId || !clientSecret) {
+		return done(error('invalid_client', 'Missing parameters. "client_id" and "client_secret" are required'));
+	}
 
-  var self = this;
-  return this.model.getUserFromClient(this.client, function (err, user) {
-    if (err) return done(error('server_error', false, err));
+	return this.model.getUserFromClient(this.client, (err, user) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!user) {
-      return done(error('invalid_grant', 'Client credentials are invalid'));
-    }
+		if (!user) {
+			return done(error('invalid_grant', 'Client credentials are invalid'));
+		}
 
-    self.user = user;
-    self.scope = self.req.body.scope || self.client.defaultScope;
+		this.user = user;
+		this.scope = this.req.body.scope || this.client.defaultScope;
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -304,25 +300,21 @@ function useClientCredentialsGrant (done) {
  *
  * @param  {Function} done
  */
-function useExtendedGrant (done) {
-  var self = this;
-  this.model.extendedGrant(this.grantType, this.req,
-      function (err, supported, user) {
-    if (err) {
-      return done(error(err.error || 'server_error',
-        err.description || err.message, err));
-    }
+function useExtendedGrant(done) {
+	this.model.extendedGrant(this.grantType, this.req, (err, supported, user) => {
+		if (err) {
+			return done(error(err.error || 'server_error', err.description || err.message, err));
+		}
 
-    if (!supported) {
-      return done(error('invalid_request',
-        'Invalid grant_type parameter or parameter missing'));
-    } else if (!user || user.id === undefined) {
-      return done(error('invalid_request', 'Invalid request.'));
-    }
+		if (!supported) {
+			return done(error('invalid_request', 'Invalid grant_type parameter or parameter missing'));
+		} else if (!user || user.id === undefined) {
+			return done(error('invalid_request', 'Invalid request.'));
+		}
 
-    self.user = user;
-    done();
-  });
+		this.user = user;
+		done();
+	});
 }
 
 /**
@@ -330,23 +322,20 @@ function useExtendedGrant (done) {
  *
  * @param  {Function} done
  */
-function useMfaOtpGrant (done) {
-  var self = this;
+function useMfaOtpGrant(done) {
+	if (!this.req.body || !this.req.body.otp || !this.req.body.mfa_token) {
+		return done(error('invalid_request', 'You must provide otp and mfa token.'));
+	}
 
-  if (!self.req.body || !self.req.body.otp || !self.req.body.mfa_token) {
-    return done(error('invalid_request', 'You must provide otp and mfa token.'));
-  }
+	this.model.performMfaOtp(this.req, (err, user) => {
+		if (err) {
+			return done(err);
+		}
 
-  this.model.performMfaOtp(this.req,
-    function (err, user) {
-      if (err) {
-          return done(err);
-      }
+		convertMfaBody(this, user);
 
-			convertMfaBody(self, user);
-
-      done();
-  });
+		done();
+	});
 }
 
 
@@ -355,22 +344,20 @@ function useMfaOtpGrant (done) {
  *
  * @param  {Function} done
  */
-function useRecoveryCodeGrant (done) {
-  var self = this;
+function useRecoveryCodeGrant(done) {
+	if (!this.req.body || !this.req.body.recovery_code || !this.req.body.mfa_token) {
+		return done(error('invalid_request', 'You must provide recovery code and mfa token.'));
+	}
 
-  if (!self.req.body || !self.req.body.recovery_code || !self.req.body.mfa_token) {
-    return done(error('invalid_request', 'You must provide recovery code and mfa token.'));
-  }
+	this.model.performRecoveryCode(this.req, (err, user) => {
+		if (err) {
+			return done(err);
+		}
 
-  this.model.performRecoveryCode(this.req, function (err, user) {
-    if (err) {
-      return done(err);
-    }
+		convertMfaBody(this, user);
 
-    convertMfaBody(self, user);
-
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -379,44 +366,44 @@ function useRecoveryCodeGrant (done) {
  * @param  {Function} done
  */
 async function useDemoAccountGrant(done) {
-  if (!this.req.body || !this.req.body.email) {
-    return done(error('invalid_request', 'You must provide an email address.'));
-  }
+	if (!this.req.body || !this.req.body.email) {
+		return done(error('invalid_request', 'You must provide an email address.'));
+	}
 
-  if (this.req.body.accepts_terms !== 'true') {
-    return done(error('invalid_request', 'You must accept the demo terms of service.'));
-  }
+	if (this.req.body.accepts_terms !== 'true') {
+		return done(error('invalid_request', 'You must accept the demo terms of service.'));
+	}
 
-  try {
-    this.user = await this.model.performDemoAccountGrant(this.req);
+	try {
+		this.user = await this.model.performDemoAccountGrant(this.req);
 
-    if (this.req.body && this.user.expires_in) {
-      this.req.body.expires_in = this.user.expires_in;
-    }
-    done();
-  } catch (err) {
-    return done(err);
-  }
+		if (this.req.body && this.user.expires_in) {
+			this.req.body.expires_in = this.user.expires_in;
+		}
+		done();
+	} catch (err) {
+		return done(err);
+	}
 }
 
 function convertMfaBody(self, user) {
-  if (user.scope) {
-    self.scope = user.scope;
-  }
+	if (user.scope) {
+		self.scope = user.scope;
+	}
 
-  if (user.client) {
-    self.client = user.client;
-  }
+	if (user.client) {
+		self.client = user.client;
+	}
 
-  if (self.req.body && user.expires_in) {
-    self.req.body.expires_in = user.expires_in
-  }
+	if (self.req.body && user.expires_in) {
+		self.req.body.expires_in = user.expires_in;
+	}
 
-  if (self.req.body && user.expires_at !== undefined) {
-    self.req.body.expires_at = user.expires_at
-  }
+	if (self.req.body && user.expires_at !== undefined) {
+		self.req.body.expires_at = user.expires_at;
+	}
 
-  self.user = user;
+	self.user = user;
 }
 
 /**
@@ -425,18 +412,19 @@ function convertMfaBody(self, user) {
  * @param  {Function} done
  * @this   OAuth
  */
-function checkGrantTypeAllowed (done) {
-  this.model.grantTypeAllowed(this.client.clientId, this.grantType,
-      function (err, allowed) {
-    if (err) return done(error('server_error', false, err));
+function checkGrantTypeAllowed(done) {
+	this.model.grantTypeAllowed(this.client.clientId, this.grantType, (err, allowed) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!allowed) {
-      return done(error('invalid_client',
-        'The grant type is unauthorised for this client_id'));
-    }
+		if (!allowed) {
+			return done(error('invalid_client',
+				'The grant type is unauthorised for this client_id'));
+		}
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -445,17 +433,19 @@ function checkGrantTypeAllowed (done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function checkScope (done) {
-  var self = this;
-  this.model.validateScope(this.scope, this.client, this.user,
-      function(err, scope, invalid) {
-    if (err) return done(error('server_error', false, err));
-    if (invalid) return done(error('invalid_scope', invalid));
+function checkScope(done) {
+	this.model.validateScope(this.scope, this.client, this.user, (err, scope, invalid) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
+		if (invalid) {
+			return done(error('invalid_scope', invalid));
+		}
 
-    self.scope = scope;
+		this.scope = scope;
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -464,10 +454,10 @@ function checkScope (done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function exposeUser (done) {
-  this.req.user = this.user;
+function exposeUser(done) {
+	this.req.user = this.user;
 
-  done();
+	done();
 }
 
 /**
@@ -476,12 +466,11 @@ function exposeUser (done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function generateAccessToken (done) {
-  var self = this;
-  token(this, 'accessToken', function (err, token) {
-    self.accessToken = token;
-    done(err);
-  });
+function generateAccessToken(done) {
+	token(this, 'accessToken', (err, token) => {
+		this.accessToken = token;
+		done(err);
+	});
 }
 
 function generateExpiresTime(done) {
@@ -491,14 +480,13 @@ function generateExpiresTime(done) {
 		return done();
 	}
 
-	var self = this;
-	this.model.generateExpiresTime(this.req, function(err, expires) {
+	this.model.generateExpiresTime(this.req, (err, expires) => {
 		if (err) {
 			return done(error('server_error', false, err));
 		}
 
 		if (expires !== undefined) {
-			self.accessTokenLifetime = expires;
+			this.accessTokenLifetime = expires;
 		}
 		done();
 	});
@@ -510,26 +498,27 @@ function generateExpiresTime(done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function saveAccessToken (done) {
-  var accessToken = this.accessToken;
+function saveAccessToken(done) {
+	const accessToken = this.accessToken;
 
-  // Object indicates a reissue
-  if (typeof accessToken === 'object' && accessToken.accessToken) {
-    this.accessToken = accessToken.accessToken;
-    return done();
-  }
+	// Object indicates a reissue
+	if (typeof accessToken === 'object' && accessToken.accessToken) {
+		this.accessToken = accessToken.accessToken;
+		return done();
+	}
 
-  var expires = null;
-  if ((this.accessTokenLifetime !== null) && (this.accessTokenLifetime > 0)) {
-    expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + this.accessTokenLifetime);
-  }
+	let expires = null;
+	if ((this.accessTokenLifetime !== null) && (this.accessTokenLifetime > 0)) {
+		expires = new Date(this.now);
+		expires.setSeconds(expires.getSeconds() + this.accessTokenLifetime);
+	}
 
-  this.model.saveAccessToken(accessToken, this.client, expires,
-      this.user, this.scope, this.grantType, function (err) {
-    if (err) return done(error('server_error', false, err));
-    done();
-  });
+	this.model.saveAccessToken(accessToken, this.client, expires, this.user, this.scope, this.grantType, (err) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
+		done();
+	});
 }
 
 /**
@@ -538,35 +527,37 @@ function saveAccessToken (done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function generateRefreshToken (done) {
-  if (this.config.grants.indexOf('refresh_token') === -1) return done();
-  if (this.grantType === 'urn:custom:demo_account') return done();
+function generateRefreshToken(done) {
+	if (this.config.grants.indexOf('refresh_token') === -1) {
+		return done();
+	}
+	if (this.grantType === 'urn:custom:demo_account') {
+		return done();
+	}
 
-  var self = this;
-  token(this, 'refreshToken', function (err, token) {
-    self.refreshToken = token;
-    done(err);
-  });
+	token(this, 'refreshToken', (err, token) => {
+		this.refreshToken = token;
+		done(err);
+	});
 }
 
 function generateRefreshExpiresTime(done) {
-  this.refreshTokenLifetime = this.config.refreshTokenLifetime;
+	this.refreshTokenLifetime = this.config.refreshTokenLifetime;
 
-  if (!this.model.generateRefreshExpiresTime) {
-    return done();
-  }
+	if (!this.model.generateRefreshExpiresTime) {
+		return done();
+	}
 
-  var self = this;
-  this.model.generateRefreshExpiresTime(this.req, function(err, expires) {
-    if (err) {
-      return done(error('server_error', false, err));
-    }
+	this.model.generateRefreshExpiresTime(this.req, (err, expires) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (expires !== undefined) {
-      self.refreshTokenLifetime = expires;
-    }
-    done();
-  });
+		if (expires !== undefined) {
+			this.refreshTokenLifetime = expires;
+		}
+		done();
+	});
 }
 
 /**
@@ -575,35 +566,38 @@ function generateRefreshExpiresTime(done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function saveRefreshToken (done) {
-  var refreshToken = this.refreshToken;
+function saveRefreshToken(done) {
+	const refreshToken = this.refreshToken;
 
-  if (!refreshToken) return done();
+	if (!refreshToken) {
+		return done();
+	}
 
-  // Object idicates a reissue
-  if (typeof refreshToken === 'object' && refreshToken.refreshToken) {
-    this.refreshToken = refreshToken.refreshToken;
-    return done();
-  }
+	// Object idicates a reissue
+	if (typeof refreshToken === 'object' && refreshToken.refreshToken) {
+		this.refreshToken = refreshToken.refreshToken;
+		return done();
+	}
 
-  // do not issue a refresh token if non-expiring access token
-  if (!this.accessTokenLifetime) {
-    this.refreshToken = null;
-    return done();
-  }
+	// do not issue a refresh token if non-expiring access token
+	if (!this.accessTokenLifetime) {
+		this.refreshToken = null;
+		return done();
+	}
 
-  var expires = null;
-  if (this.refreshTokenLifetime) {
-    expires = new Date(this.now);
-    // refresh extends past access token lifetime
-    expires.setSeconds(expires.getSeconds() + this.accessTokenLifetime + this.refreshTokenLifetime);
-  }
+	let expires = null;
+	if (this.refreshTokenLifetime) {
+		expires = new Date(this.now);
+		// refresh extends past access token lifetime
+		expires.setSeconds(expires.getSeconds() + this.accessTokenLifetime + this.refreshTokenLifetime);
+	}
 
-  this.model.saveRefreshToken(refreshToken, this.client.clientId, expires,
-      this.user, this.scope, function (err) {
-    if (err) return done(error('server_error', false, err));
-    done();
-  });
+	this.model.saveRefreshToken(refreshToken, this.client.clientId, expires, this.user, this.scope, (err) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
+		done();
+	});
 }
 
 /**
@@ -613,15 +607,17 @@ function saveRefreshToken (done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function checkMfa (done) {
-  if (this.user && this.user.mfaEnabled && this.grantType === 'password') {
-    this.model.saveMfaToken(this.user, this.req, this.client.clientId, function (err, result) {
-      if (err) return done(error('server_error', false, err));
-      return done(error('mfa_required', result.mfa_token));
-    });
-  } else {
-    done();
-  }
+function checkMfa(done) {
+	if (this.user && this.user.mfaEnabled && this.grantType === 'password') {
+		this.model.saveMfaToken(this.user, this.req, this.client.clientId, (err, result) => {
+			if (err) {
+				return done(error('server_error', false, err));
+			}
+			return done(error('mfa_required', result.mfa_token));
+		});
+	} else {
+		done();
+	}
 }
 
 /**
@@ -630,36 +626,37 @@ function checkMfa (done) {
  * @param  {Function} done
  * @this   OAuth
  */
-function sendResponse (done) {
-  var response = {
-    token_type: 'bearer',
-    access_token: this.accessToken
-  };
+function sendResponse(done) {
+	const response = {
+		token_type: 'bearer',
+		access_token: this.accessToken
+	};
 
-  if (this.accessTokenLifetime !== null) {
-    response.expires_in = this.accessTokenLifetime;
+	if (this.accessTokenLifetime !== null) {
+		response.expires_in = this.accessTokenLifetime;
 
-    if (this.grantType === 'urn:custom:demo_account') {
-      // Console uses this for displaying the demo timer banner
-      response.expires_at = new Date(Date.now() + this.accessTokenLifetime * 1000).toISOString();
-    }
-  }
+		if (this.grantType === 'urn:custom:demo_account') {
+			// Console uses this for displaying the demo timer banner
+			response.expires_at = new Date(Date.now() + this.accessTokenLifetime * 1000).toISOString();
+		}
+	}
 
-  if (this.refreshToken) {
-    response.refresh_token = this.refreshToken;
-  }
+	if (this.refreshToken) {
+		response.refresh_token = this.refreshToken;
+	}
 
-  if (this.scope) {
-    response.scope = this.scope;
-  }
+	if (this.scope) {
+		response.scope = this.scope;
+	}
 
-  if (this.options.skipResponse) {
-    return done();
-  }
+	if (this.options.skipResponse) {
+		return done();
+	}
 
-  this.res.set({'Cache-Control': 'no-store', 'Pragma': 'no-cache'});
-  this.res.jsonp(response);
+	this.res.set({ 'Cache-Control': 'no-store', 'Pragma': 'no-cache' });
+	this.res.jsonp(response);
 
-  if (this.config.continueAfterResponse)
-    done();
+	if (this.config.continueAfterResponse) {
+		done();
+	}
 }

--- a/lib/implicit.js
+++ b/lib/implicit.js
@@ -1,42 +1,44 @@
-var error = require('./error'),
-  runner = require('./runner'),
-  token = require('./token');
+'use strict';
+
+const error = require('./error'),
+	runner = require('./runner'),
+	token = require('./token');
 
 module.exports = ImplicitGrant;
 
-var fns = [
-  checkParams,
-  checkClient,
-  checkUserApproved,
-  generateAccessToken,
-  generateExpiresTime,
-  saveAccessToken,
-  redirect
+const fns = [
+	checkParams,
+	checkClient,
+	checkUserApproved,
+	generateAccessToken,
+	generateExpiresTime,
+	saveAccessToken,
+	redirect
 ];
 
 function ImplicitGrant(config, req, res, next, check) {
-  this.config = config;
-  this.model = config.model;
-  this.now = new Date();
-  this.req = req;
-  this.res = res;
-  this.check = check;
+	this.config = config;
+	this.model = config.model;
+	this.now = new Date();
+	this.req = req;
+	this.res = res;
+	this.check = check;
 
-  var self = this;
+	const self = this;
 
-  runner(fns, this, function (err) {
-    if (err) {
-      if (res.oauthRedirect) {
-        // Custom redirect error handler
-        res.redirect(self.client.redirectUri + '?error=' + err.error +
+	runner(fns, this, (err) => {
+		if (err) {
+			if (res.oauthRedirect) {
+				// Custom redirect error handler
+				res.redirect(self.client.redirectUri + '?error=' + err.error +
           '&error_description=' + err.error_description + '&code=' + err.code);
 
-        return self.config.continueAfterResponse ? next() : null;
-      }
-      return next(err);
-    }
-    next();
-  });
+				return self.config.continueAfterResponse ? next() : null;
+			}
+			return next(err);
+		}
+		next();
+	});
 }
 
 /**
@@ -46,32 +48,34 @@ function ImplicitGrant(config, req, res, next, check) {
  * @this   OAuth
  */
 function checkParams (done) {
-  var body = this.req.body;
-  var query = this.req.query;
-  if (!body && !query) return done(error('invalid_request'));
+	const body = this.req.body;
+	const query = this.req.query;
+	if (!body && !query) {
+		return done(error('invalid_request'));
+	}
 
-  // Response type
-  this.responseType = body.response_type || query.response_type;
-  if (this.responseType !== 'token') {
-    return done(error('invalid_request',
-      'Invalid response_type parameter (must be "token")'));
-  }
+	// Response type
+	this.responseType = body.response_type || query.response_type;
+	if (this.responseType !== 'token') {
+		return done(error('invalid_request',
+			'Invalid response_type parameter (must be "token")'));
+	}
 
-  // Client
-  this.clientId = body.client_id || query.client_id;
-  if (!this.clientId) {
-    return done(error('invalid_request',
-      'Invalid or missing client_id parameter'));
-  }
+	// Client
+	this.clientId = body.client_id || query.client_id;
+	if (!this.clientId) {
+		return done(error('invalid_request',
+			'Invalid or missing client_id parameter'));
+	}
 
-  // Redirect URI
-  this.redirectUri = body.redirect_uri || query.redirect_uri;
-  if (!this.redirectUri) {
-    return done(error('invalid_request',
-      'Invalid or missing redirect_uri parameter'));
-  }
+	// Redirect URI
+	this.redirectUri = body.redirect_uri || query.redirect_uri;
+	if (!this.redirectUri) {
+		return done(error('invalid_request',
+			'Invalid or missing redirect_uri parameter'));
+	}
 
-  done();
+	done();
 }
 
 /**
@@ -81,29 +85,30 @@ function checkParams (done) {
  * @this   OAuth
  */
 function checkClient (done) {
-  var self = this;
-  this.model.getClient(this.clientId, null, function (err, client) {
-    if (err) return done(error('server_error', false, err));
+	this.model.getClient(this.clientId, null, (err, client) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!client) {
-      return done(error('invalid_client', 'Invalid client credentials'));
-    } else if (Array.isArray(client.redirectUri)) {
-      if (client.redirectUri.indexOf(self.redirectUri) === -1) {
-        return done(error('invalid_request', 'redirect_uri does not match'));
-      }
-      client.redirectUri = self.redirectUri;
-    } else if (client.redirectUri !== self.redirectUri) {
-      return done(error('invalid_request', 'redirect_uri does not match'));
-    }
+		if (!client) {
+			return done(error('invalid_client', 'Invalid client credentials'));
+		} else if (Array.isArray(client.redirectUri)) {
+			if (client.redirectUri.indexOf(this.redirectUri) === -1) {
+				return done(error('invalid_request', 'redirect_uri does not match'));
+			}
+			client.redirectUri = this.redirectUri;
+		} else if (client.redirectUri !== this.redirectUri) {
+			return done(error('invalid_request', 'redirect_uri does not match'));
+		}
 
-    // The request contains valid params so any errors after this point
-    // are redirected to the redirect_uri
-    self.res.redirectUri = client.redirectUri;
-    self.res.oauthRedirect = true;
-    self.client = client;
+		// The request contains valid params so any errors after this point
+		// are redirected to the redirect_uri
+		this.res.redirectUri = client.redirectUri;
+		this.res.oauthRedirect = true;
+		this.client = client;
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -113,20 +118,21 @@ function checkClient (done) {
  * @this   OAuth
  */
 function checkUserApproved (done) {
-  var self = this;
-  this.check(this.req, this.client, function (err, allowed, user, scope) {
-    if (err) return done(error('server_error', false, err));
+	this.check(this.req, this.client, (err, allowed, user, scope) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (!allowed) {
-      return done(error('access_denied',
-        'The user denied access to your application'));
-    }
+		if (!allowed) {
+			return done(error('access_denied',
+				'The user denied access to your application'));
+		}
 
-    self.user = user;
-    self.scope = scope;
+		this.user = user;
+		this.scope = scope;
 
-    done();
-  });
+		done();
+	});
 }
 
 /**
@@ -136,31 +142,29 @@ function checkUserApproved (done) {
  * @this   OAuth
  */
 function generateAccessToken (done) {
-  var self = this;
-  token(this, 'accessToken', function (err, atoken) {
-    self.accessToken = atoken;
-    done(err);
-  });
+	token(this, 'accessToken', (err, atoken) => {
+		this.accessToken = atoken;
+		done(err);
+	});
 }
 
 function generateExpiresTime(done) {
-  this.accessTokenLifetime = this.config.accessTokenLifetime;
+	this.accessTokenLifetime = this.config.accessTokenLifetime;
 
-  if (!this.model.generateExpiresTime) {
-    return done();
-  }
+	if (!this.model.generateExpiresTime) {
+		return done();
+	}
 
-  var self = this;
-  this.model.generateExpiresTime(this.req, function(err, expires) {
-    if (err) {
-      return done(error('server_error', false, err));
-    }
+	this.model.generateExpiresTime(this.req, (err, expires) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
 
-    if (expires !== undefined) {
-      self.accessTokenLifetime = expires;
-    }
-    done();
-  });
+		if (expires !== undefined) {
+			this.accessTokenLifetime = expires;
+		}
+		done();
+	});
 }
 
 /**
@@ -170,25 +174,27 @@ function generateExpiresTime(done) {
  * @this   OAuth
  */
 function saveAccessToken (done) {
-  var accessToken = this.accessToken;
+	const accessToken = this.accessToken;
 
-  // Object indicates a reissue
-  if (typeof accessToken === 'object' && accessToken.accessToken) {
-    this.accessToken = accessToken.accessToken;
-    return done();
-  }
+	// Object indicates a reissue
+	if (typeof accessToken === 'object' && accessToken.accessToken) {
+		this.accessToken = accessToken.accessToken;
+		return done();
+	}
 
-  var expires = null;
-  if ((this.accessTokenLifetime !== null) && (this.accessTokenLifetime > 0)) {
-    expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + this.accessTokenLifetime);
-  }
+	let expires = null;
+	if ((this.accessTokenLifetime !== null) && (this.accessTokenLifetime > 0)) {
+		expires = new Date(this.now);
+		expires.setSeconds(expires.getSeconds() + this.accessTokenLifetime);
+	}
 
-  this.model.saveAccessToken(accessToken, this.client, expires,
-      this.user, this.scope, this.grantType, function (err) {
-    if (err) return done(error('server_error', false, err));
-    done();
-  });
+	this.model.saveAccessToken(accessToken, this.client, expires,
+		this.user, this.scope, this.grantType, (err) => {
+			if (err) {
+				return done(error('server_error', false, err));
+			}
+			done();
+		});
 }
 
 /**
@@ -198,9 +204,10 @@ function saveAccessToken (done) {
  * @this   OAuth
  */
 function redirect (done) {
-  this.res.redirect(this.client.redirectUri + '#token=' + this.accessToken +
+	this.res.redirect(this.client.redirectUri + '#token=' + this.accessToken +
       (this.req.query.state ? '&state=' + this.req.query.state : ''));
 
-  if (this.config.continueAfterResponse)
-    return done();
+	if (this.config.continueAfterResponse) {
+		return done();
+	}
 }

--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var error = require('./error'),
-  AuthCodeGrant = require('./authCodeGrant'),
-  Authorise = require('./authorise'),
-  Grant = require('./grant'),
-  Scope = require('./scope'),
-  ImplicitGrant = require('./implicit');
+const error = require('./error'),
+	AuthCodeGrant = require('./authCodeGrant'),
+	Authorise = require('./authorise'),
+	Grant = require('./grant'),
+	Scope = require('./scope'),
+	ImplicitGrant = require('./implicit');
 
 module.exports = OAuth2Server;
 
@@ -30,31 +31,36 @@ module.exports = OAuth2Server;
  */
 function OAuth2Server (config) {
 
-  if (!(this instanceof OAuth2Server)) return new OAuth2Server(config);
+	if (!(this instanceof OAuth2Server)) {
+		return new OAuth2Server(config);
+	}
 
-  config = config || {};
+	config = config || {};
 
-  if (!config.model) throw new Error('No model supplied to OAuth2Server');
-  this.model = config.model;
+	if (!config.model) {
+		throw new Error('No model supplied to OAuth2Server');
+	}
+	this.model = config.model;
 
-  this.grants = config.grants || [];
-  this.debug = config.debug || function () {};
-  if (typeof this.debug !== 'function') {
-      this.debug = console.log;
-  }
-  this.passthroughErrors = config.passthroughErrors;
-  this.continueAfterResponse = config.continueAfterResponse;
+	this.grants = config.grants || [];
+	this.debug = config.debug || (() => {});
+	if (typeof this.debug !== 'function') {
+		// eslint-disable-next-line no-console
+		this.debug = console.log;
+	}
+	this.passthroughErrors = config.passthroughErrors;
+	this.continueAfterResponse = config.continueAfterResponse;
 
-  this.accessTokenLifetime = config.accessTokenLifetime !== undefined ?
-    config.accessTokenLifetime : 3600;
-  this.refreshTokenLifetime = config.refreshTokenLifetime !== undefined ?
-    config.refreshTokenLifetime : 1209600;
-  this.authCodeLifetime = config.authCodeLifetime || 30;
+	this.accessTokenLifetime = config.accessTokenLifetime !== undefined ?
+		config.accessTokenLifetime : 3600;
+	this.refreshTokenLifetime = config.refreshTokenLifetime !== undefined ?
+		config.refreshTokenLifetime : 1209600;
+	this.authCodeLifetime = config.authCodeLifetime || 30;
 
-  this.regex = {
-    clientId: config.clientIdRegex || /^[a-z0-9-_]{3,40}$/i,
-    grantType: new RegExp('^(' + this.grants.join('|') + ')$', 'i')
-  };
+	this.regex = {
+		clientId: config.clientIdRegex || /^[a-z0-9-_]{3,40}$/i,
+		grantType: new RegExp('^(' + this.grants.join('|') + ')$', 'i')
+	};
 }
 
 /**
@@ -65,12 +71,12 @@ function OAuth2Server (config) {
  *
  * @return {Function} middleware
  */
-OAuth2Server.prototype.authorise = function (options) {
-  var self = this;
+OAuth2Server.prototype.authorise = function authorise(options) {
+	const self = this;
 
-  return function oauthAuthorise(req, res, next) {
-    return new Authorise(self, req, res, options, next);
-  };
+	return function oauthAuthorise(req, res, next) {
+		return new Authorise(self, req, res, options, next);
+	};
 };
 
 /**
@@ -83,12 +89,12 @@ OAuth2Server.prototype.authorise = function (options) {
  *
  * @return {Function} middleware
  */
-OAuth2Server.prototype.grant = function (options) {
-  var self = this;
+OAuth2Server.prototype.grant = function grant(options) {
+	const self = this;
 
-  return function oauthGrant(req, res, next) {
-    return new Grant(self, options, req, res, next);
-  };
+	return function oauthGrant(req, res, next) {
+		return new Grant(self, options, req, res, next);
+	};
 };
 
 /**
@@ -98,12 +104,12 @@ OAuth2Server.prototype.grant = function (options) {
  *                          user has authorised the request.
  * @return {Function}       middleware
  */
-OAuth2Server.prototype.authCodeGrant = function (check) {
-  var self = this;
+OAuth2Server.prototype.authCodeGrant = function authCodeGrant(check) {
+	const self = this;
 
-  return function oauthAuthCodeGrant(req, res, next) {
-    new AuthCodeGrant(self, req, res, next, check);
-  };
+	return function oauthAuthCodeGrant(req, res, next) {
+		new AuthCodeGrant(self, req, res, next, check);
+	};
 };
 
 /**
@@ -113,31 +119,31 @@ OAuth2Server.prototype.authCodeGrant = function (check) {
  * @param  {Function} handler middleware
  * @return {Function}         middleware
  */
-OAuth2Server.prototype.implicit = function(check) {
-  var self = this;
-  return function oauthImplicit(req, res, next) {
-    new ImplicitGrant(self, req, res, next, check);
-  };
+OAuth2Server.prototype.implicit = function implicit(check) {
+	const self = this;
+	return function oauthImplicit(req, res, next) {
+		new ImplicitGrant(self, req, res, next, check);
+	};
 };
 
-OAuth2Server.prototype.implicitRedirect = function() {
-  var errfunc = function (err, req, res, next) {
-    if (res.oauthRedirect && res.redirectUri) {
-      return res.redirect(res.redirectUri + '?error=' + err.error +
+OAuth2Server.prototype.implicitRedirect = function implicitRedirect() {
+	const errfunc = (err, req, res, next) => {
+		if (res.oauthRedirect && res.redirectUri) {
+			return res.redirect(res.redirectUri + '?error=' + err.error +
           '&error_description=' + err.error_description + '&code=' + err.code);
-    }
-    next(err);
-  };
+		}
+		next(err);
+	};
 
-  var goodfunc = function (req, res, next) {
-    if (res.oauthRedirect && res.redirectUri) {
-      return res.redirect(res.redirectUri + '#token=' + res.accessToken +
+	const goodfunc = (req, res, next) => {
+		if (res.oauthRedirect && res.redirectUri) {
+			return res.redirect(res.redirectUri + '#token=' + res.accessToken +
           (req.query.state ? '&state=' + req.query.state : ''));
-    }
-    next();
-  };
+		}
+		next();
+	};
 
-  return [errfunc, goodfunc];
+	return [errfunc, goodfunc];
 };
 
 /**
@@ -150,12 +156,12 @@ OAuth2Server.prototype.implicitRedirect = function() {
  *                                  required to access the route.
  * @return {Function}
  */
-OAuth2Server.prototype.scope = function(requiredScope) {
-  var self = this;
+OAuth2Server.prototype.scope = function scope(requiredScope) {
+	const self = this;
 
-  return function oauthScope(req, res, next) {
-    return new Scope(self, req, next, requiredScope);
-  };
+	return function oauthScope(req, res, next) {
+		return new Scope(self, req, next, requiredScope);
+	};
 };
 
 /**
@@ -166,25 +172,29 @@ OAuth2Server.prototype.scope = function(requiredScope) {
  *
  * @return {Function} middleware
  */
-OAuth2Server.prototype.errorHandler = function () {
-  var self = this;
+OAuth2Server.prototype.errorHandler = function errorHandler() {
+	const self = this;
 
-  return function oauthErrorHandler(err, req, res, next) {
-    if (!(err instanceof error) || self.passthroughErrors || res.headersSent) return next(err);
+	return function oauthErrorHandler(err, req, res, next) {
+		if (!(err instanceof error) || self.passthroughErrors || res.headersSent) {
+			return next(err);
+		}
 
-    delete err.name;
-    delete err.message;
+		delete err.name;
+		delete err.message;
 
-    self.debug(err.stack || err);
-    delete err.stack;
+		self.debug(err.stack || err);
+		delete err.stack;
 
-    if (err.headers) res.set(err.headers);
-    delete err.headers;
+		if (err.headers) {
+			res.set(err.headers);
+		}
+		delete err.headers;
 
-    res.status(err.code);
-    delete err.code;
-    res.send(err);
-  };
+		res.status(err.code);
+		delete err.code;
+		res.send(err);
+	};
 };
 
 /**
@@ -215,82 +225,83 @@ OAuth2Server.prototype.errorHandler = function () {
  *
  * @param  {Object} app Express app
  */
-OAuth2Server.prototype.lockdown = function (app) {
-  var self = this;
+OAuth2Server.prototype.lockdown = function lockdown(app) {
+	const self = this;
 
-  var lockdownExpress3 = function (stack) {
-    // Check if it's a grant route
-    var pos = stack.indexOf(self.grant);
-    if (pos !== -1) {
-      stack[pos] = self.grant();
-      return;
-    }
+	function lockdownExpress3(stack) {
+		// Check if it's a grant route
+		let pos = stack.indexOf(self.grant);
+		if (pos !== -1) {
+			stack[pos] = self.grant();
+			return;
+		}
 
-    // Check it's not been explitly bypassed
-    pos = stack.indexOf(self.bypass);
-    if (pos === -1) {
-      stack.unshift(self.authorise());
-    } else {
-      stack.splice(pos, 1);
-    }
-  };
+		// Check it's not been explitly bypassed
+		pos = stack.indexOf(self.bypass);
+		if (pos === -1) {
+			stack.unshift(self.authorise());
+		} else {
+			stack.splice(pos, 1);
+		}
+	};
 
-  var lockdownExpress4 = function (layer) {
-    if (layer.name === 'router') {
-      const handle = layer.handle.__original || layer.handle._datadog_orig || layer.handle;
-      handle.stack.forEach(lockdownExpress4);
-      return;
-    }
+	function lockdownExpress4 (layer) {
+		if (layer.name === 'router') {
+			const handle = layer.handle.__original || layer.handle._datadog_orig || layer.handle;
+			handle.stack.forEach(lockdownExpress4);
+			return;
+		}
 
-    if (!layer.route)
-      return;
+		if (!layer.route) {
+			return;
+		}
 
-    var stack = layer.route.stack;
-    var handlers = stack.map(function (item) {
-      return item.handle.__original || item.handle._datadog_orig || item.handle;
-    });
+		const stack = layer.route.stack;
+		const handlers = stack.map((item) => {
+			return item.handle.__original || item.handle._datadog_orig || item.handle;
+		});
 
-    // Check if it's a grant route
-    var pos;
-    var isGrant = false;
-    while ((pos = handlers.indexOf(self.grant)) !== -1) {
-      stack[pos].handle = self.grant();
-      handlers[pos] = null;
-      isGrant = true;
-    }
-    if (isGrant) {
-      return;
-    }
+		// Check if it's a grant route
+		let pos;
+		let isGrant = false;
+		while ((pos = handlers.indexOf(self.grant)) !== -1) {
+			stack[pos].handle = self.grant();
+			handlers[pos] = null;
+			isGrant = true;
+		}
+		if (isGrant) {
+			return;
+		}
 
-    // Check it's not been explitly bypassed
-    pos = handlers.indexOf(self.bypass);
-    if (pos === -1) {
-      // Add authorise another route that applies to all methods
-      var copy = {};
-      var first = stack[0];
-      for (var key in first) {
-        copy[key] = first[key];
-      }
-      delete copy.method;
-      copy.handle = self.authorise();
-      stack.unshift(copy);
-    } else {
-      while ((pos = handlers.indexOf(self.bypass)) !== -1) {
-        stack.splice(pos, 1);
-        handlers[pos] = null;
-      }
-    }
-  };
+		// Check it's not been explitly bypassed
+		pos = handlers.indexOf(self.bypass);
+		if (pos === -1) {
+			// Add authorise another route that applies to all methods
+			const copy = {};
+			const first = stack[0];
+			for (const key in first) {
+				copy[key] = first[key];
+			}
+			delete copy.method;
+			copy.handle = self.authorise();
+			stack.unshift(copy);
+		} else {
+			while ((pos = handlers.indexOf(self.bypass)) !== -1) {
+				stack.splice(pos, 1);
+				handlers[pos] = null;
+			}
+		}
+	};
 
-  if (app.routes) {
-    for (var method in app.routes) {
-      app.routes[method].forEach(function (route) {
-        lockdownExpress3(route.callbacks);
-      });
-    }
-  } else {
-    app._router.stack.forEach(lockdownExpress4);
-  }
+	if (app.routes) {
+		for (const method in app.routes) {
+			app.routes[method].forEach((route) => {
+				lockdownExpress3(route.callbacks);
+			});
+		}
+	} else {
+		app._router.stack.forEach(lockdownExpress4);
+	}
 };
 
 /**
@@ -300,4 +311,4 @@ OAuth2Server.prototype.lockdown = function (app) {
  *
  * @return {Function} noop
  */
-OAuth2Server.prototype.bypass = function () {};
+OAuth2Server.prototype.bypass = function bypass() {};

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,20 +1,26 @@
-
-
-module.exports = runner;
+'use strict';
 
 /**
  * Run through the sequence of functions
  *
- * @param  {Function} next
+ * @param {Function[]} fns
+ * @param {this} context
+ * @param {Function} next
  * @public
  */
-function runner (fns, context, next) {
-  var last = fns.length - 1;
+function runner(fns, context, next) {
+	const last = fns.length - 1;
 
-  (function run(pos) {
-    fns[pos].call(context, function (err) {
-      if (err || pos === last) return next(err);
-      run(++pos);
-    });
-  })(0);
+	function run(pos) {
+		fns[pos].call(context, (err) => {
+			if (err || pos === last) {
+				return next(err);
+			}
+			run(pos + 1);
+		});
+	}
+
+	run(0);
 }
+
+module.exports = runner;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var error = require('./error'),
-  runner = require('./runner');
+const error = require('./error'),
+	runner = require('./runner');
 
 module.exports = Scope;
 
@@ -24,8 +25,8 @@ module.exports = Scope;
  *
  * @type {Array}
  */
-var fns = [
-  checkScope
+const fns = [
+	checkScope
 ];
 
 /**
@@ -37,12 +38,12 @@ var fns = [
  * @param {Mixed}    scope String or list of required scopes
  */
 function Scope (config, req, next, scope) {
-  this.config = config;
-  this.model = config.model;
-  this.req = req;
-  this.scope = scope;
+	this.config = config;
+	this.model = config.model;
+	this.req = req;
+	this.scope = scope;
 
-  runner(fns, this, next);
+	runner(fns, this, next);
 }
 
 /**
@@ -56,12 +57,18 @@ function Scope (config, req, next, scope) {
  *
  */
 function checkScope (done) {
-  if (!this.req.oauth) return done(error('invalid_request', 'Request not authenticated'));
+	if (!this.req.oauth) {
+		return done(error('invalid_request', 'Request not authenticated'));
+	}
 
-  this.model.authoriseScope(this.req.oauth.bearerToken, this.scope, function (err, invalid) {
-    if (err) return done(error('server_error', false, err));
-    if (invalid) return done(error('invalid_scope', invalid));
+	this.model.authoriseScope(this.req.oauth.bearerToken, this.scope, (err, invalid) => {
+		if (err) {
+			return done(error('server_error', false, err));
+		}
+		if (invalid) {
+			return done(error('invalid_scope', invalid));
+		}
 
-    done();
-  });
+		done();
+	});
 }

--- a/lib/token.js
+++ b/lib/token.js
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var crypto = require('crypto'),
-  error = require('./error');
-
-module.exports = Token;
+const crypto = require('crypto'),
+	error = require('./error');
 
 /**
  * Token generator that will delegate to model or
@@ -26,16 +25,20 @@ module.exports = Token;
  * @param  {String}   type     'accessToken' or 'refreshToken'
  * @param  {Function} callback
  */
-function Token (config, type, callback) {
-  if (config.model.generateToken) {
-    config.model.generateToken(type, config.req, function (err, token) {
-      if (err) return callback(error('server_error', false, err));
-      if (!token) return generateRandomToken(callback);
-      callback(false, token);
-    });
-  } else {
-    generateRandomToken(callback);
-  }
+function Token(config, type, callback) {
+	if (config.model.generateToken) {
+		config.model.generateToken(type, config.req, (err, token) => {
+			if (err) {
+				return callback(error('server_error', false, err));
+			}
+			if (!token) {
+				return generateRandomToken(callback);
+			}
+			callback(false, token);
+		});
+	} else {
+		generateRandomToken(callback);
+	}
 }
 
 /**
@@ -43,15 +46,19 @@ function Token (config, type, callback) {
  *
  * @param  {Function} callback
  */
-var generateRandomToken = function (callback) {
-  crypto.randomBytes(256, function (ex, buffer) {
-    if (ex) return callback(error('server_error'));
+function generateRandomToken(callback) {
+	crypto.randomBytes(256, (ex, buffer) => {
+		if (ex) {
+			return callback(error('server_error'));
+		}
 
-    var token = crypto
-      .createHash('sha1')
-      .update(buffer)
-      .digest('hex');
+		const token = crypto
+			.createHash('sha1')
+			.update(buffer)
+			.digest('hex');
 
-    callback(false, token);
-  });
-};
+		callback(false, token);
+	});
+}
+
+module.exports = Token;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
       },
       "devDependencies": {
         "body-parser": "^1.18.2",
+        "eslint": "^9.39.3",
+        "eslint-config-particle": "^3.0.3",
         "expect": "^30.2.0",
         "express": "^4.18.2",
         "mocha": "^7.2.0",
@@ -45,6 +47,349 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.71.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.71.0.tgz",
+      "integrity": "sha512-2p9+dXWNQnp5Kq/V0XVWZiVAabzlX6rUW8vXXvtX8Yc1CkKgD93IPDEnv1sYZFkkS6HMvg6H0RMZfob/Co0YXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@typescript-eslint/types": "^8.46.0",
+        "comment-parser": "1.4.1",
+        "esquery": "^1.6.0",
+        "jsdoc-type-pratt-parser": "~6.6.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
+      "integrity": "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.40 || 9"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
+      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.3",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
+      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jest/diff-sequences": {
@@ -232,6 +577,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -258,6 +610,13 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.3.0",
@@ -293,6 +652,401 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -305,6 +1059,46 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-colors": {
@@ -352,6 +1146,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -630,6 +1434,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -786,6 +1600,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.1.tgz",
+      "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -849,6 +1673,37 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -923,6 +1778,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -1232,6 +2094,442 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
+      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.3",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-particle": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-particle/-/eslint-config-particle-3.0.3.tgz",
+      "integrity": "sha512-7OqqbKjPh6W791WvbZRY+BYeThwkTGHtOVNMKk2Wbs7wAC4eZBwu3ms2Bs0fcz+ySLNT+0jN+y/JF1vsd5JQbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/compat": "^1.4.0",
+        "@eslint/js": "^9.36.0",
+        "@typescript-eslint/eslint-plugin": "^8.45.0",
+        "@typescript-eslint/parser": "^8.45.0",
+        "eslint-plugin-jsdoc": "^60.7.1",
+        "globals": "^16.4.0",
+        "typescript-eslint": "^8.45.0"
+      },
+      "engines": {
+        "node": ">=22.18"
+      },
+      "peerDependencies": {
+        "eslint": "^9.36.0"
+      }
+    },
+    "node_modules/eslint-config-particle/node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "60.8.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-60.8.3.tgz",
+      "integrity": "sha512-4191bTMvnd5WUtopCdzNhQchvv/MxtPD86ZGl3vem8Ibm22xJhKuIyClmgSxw+YERtorVc/NhG+bGjfFVa6+VQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.71.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.1",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^10.4.0",
+        "esquery": "^1.6.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^1.0.5",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.7.2",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1244,6 +2542,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -1337,12 +2681,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1401,6 +2779,27 @@
       "bin": {
         "flat": "cli.js"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -1635,6 +3034,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -1786,6 +3198,23 @@
         "he": "bin/he"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1814,6 +3243,43 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
@@ -2723,6 +4189,61 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.6.0.tgz",
+      "integrity": "sha512-3hSD14nXx66Rspx1RMnz1Pj4JacrMBAsC0CrF9lZYO/Qsp5/oIr6KqujVUNhQu94B6mMip2ukki8MpEWZwyhKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -2741,6 +4262,13 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2952,6 +4480,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -2981,6 +4516,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-deep-merge": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-1.0.5.tgz",
+      "integrity": "sha512-3DioFgOzetbxbeUq8pB2NunXo8V0n4EvqsWM/cJoI6IA9zghd7cl/2pBOuWRf4dlvA+fcg5ugFMZaN2/RuoaGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "4.2.0"
       }
     },
     "node_modules/object-inspect": {
@@ -3067,6 +4612,24 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -3124,6 +4687,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3152,6 +4745,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3189,6 +4792,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-format": {
@@ -3231,6 +4844,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3355,6 +4978,16 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -3597,6 +5230,29 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/should": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/should/-/should-4.0.4.tgz",
@@ -3688,6 +5344,31 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -3923,6 +5604,54 @@
         "node": ">=6"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3944,6 +5673,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.2.0.tgz",
+      "integrity": "sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -4038,6 +5806,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.1",
+        "@typescript-eslint/parser": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -4072,6 +5879,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/utils-merge": {
@@ -4218,6 +6035,16 @@
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -4368,6 +6195,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
         "expect": "^30.2.0",
         "express": "^4.18.2",
         "mocha": "^7.2.0",
-        "should": "~4.0.4",
+        "should": "~13.2.3",
         "supertest": "^7.2.2"
       },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5254,10 +5254,64 @@
       }
     },
     "node_modules/should": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/should/-/should-4.0.4.tgz",
-      "integrity": "sha1-jvqjBPHxSM89LpVYYpkPmrnqYo8=",
-      "dev": true
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "node_modules/should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "node_modules/should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "node_modules/should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "basic-auth": "~0.0.1"
       },
       "devDependencies": {
-        "body-parser": "^1.18.2",
+        "body-parser": "^1.20.4",
         "eslint": "^9.39.3",
         "eslint-config-particle": "^3.0.3",
         "expect": "^30.2.0",
@@ -1303,44 +1303,75 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/body-parser/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/brace-expansion": {
@@ -2665,6 +2696,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express/node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/express/node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -2679,6 +2735,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/express/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4883,17 +4955,48 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "basic-auth": "~0.0.1"
   },
   "devDependencies": {
-    "body-parser": "^1.18.2",
+    "body-parser": "^1.20.4",
     "eslint": "^9.39.3",
     "eslint-config-particle": "^3.0.3",
     "expect": "^30.2.0",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,17 @@
     }
   ],
   "main": "lib/oauth2server.js",
+  "scripts": {
+    "lint": "eslint",
+    "test": "mocha --exit --recursive '**/*.test.js'"
+  },
   "dependencies": {
     "basic-auth": "~0.0.1"
   },
   "devDependencies": {
     "body-parser": "^1.18.2",
+    "eslint": "^9.39.3",
+    "eslint-config-particle": "^3.0.3",
     "expect": "^30.2.0",
     "express": "^4.18.2",
     "mocha": "^7.2.0",
@@ -35,10 +41,7 @@
     }
   ],
   "engines": {
-    "node": ">=0.8"
-  },
-  "scripts": {
-    "test": "mocha --exit --recursive '**/*.test.js'"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "expect": "^30.2.0",
     "express": "^4.18.2",
     "mocha": "^7.2.0",
-    "should": "~4.0.4",
+    "should": "~13.2.3",
     "supertest": "^7.2.2"
   },
   "licenses": [

--- a/test/authCodeGrant.test.js
+++ b/test/authCodeGrant.test.js
@@ -13,397 +13,410 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest'),
+	should = require('should');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (model, params, continueAfterResponse) {
+function bootstrap(model, params, continueAfterResponse) {
 
-  var app = express();
-  app.oauth = oauth2server({
-    model: model || {},
-    continueAfterResponse: continueAfterResponse
-  });
+	const app = express();
+	app.oauth = oauth2server({
+		model: model || {},
+		continueAfterResponse: continueAfterResponse
+	});
 
-  app.use(bodyParser());
+	app.use(bodyParser());
 
-  app.post('/authorise', app.oauth.authCodeGrant(function (req, client, next) {
-    next.apply(null, params || []);
-  }));
+	app.post('/authorise', app.oauth.authCodeGrant(function (req, client, next) {
+		next.apply(null, params || []);
+	}));
 
-  app.get('/authorise', app.oauth.authCodeGrant(function (req, client, next) {
-    next.apply(null, params || []);
-  }));
+	app.get('/authorise', app.oauth.authCodeGrant(function (req, client, next) {
+		next.apply(null, params || []);
+	}));
 
-  app.use(app.oauth.errorHandler());
+	app.use(app.oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
-describe('AuthCodeGrant', function() {
+describe('AuthCodeGrant', function () {
+	it('should detect no response type', function (done) {
+		const app = bootstrap();
 
-  it('should detect no response type', function (done) {
-    var app = bootstrap();
+		request(app)
+			.post('/authorise')
+			.expect(400, /invalid response_type parameter/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .expect(400, /invalid response_type parameter/i, done);
-  });
+	it('should detect invalid response type', function (done) {
+		const app = bootstrap();
 
-  it('should detect invalid response type', function (done) {
-    var app = bootstrap();
+		request(app)
+			.post('/authorise')
+			.send({ response_type: 'token' })
+			.expect(400, /invalid response_type parameter/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({ response_type: 'token' })
-      .expect(400, /invalid response_type parameter/i, done);
-  });
+	it('should detect no client_id', function (done) {
+		const app = bootstrap();
 
-  it('should detect no client_id', function (done) {
-    var app = bootstrap();
+		request(app)
+			.post('/authorise')
+			.send({ response_type: 'code' })
+			.expect(400, /invalid or missing client_id parameter/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({ response_type: 'code' })
-      .expect(400, /invalid or missing client_id parameter/i, done);
-  });
+	it('should detect no redirect_uri', function (done) {
+		const app = bootstrap();
 
-  it('should detect no redirect_uri', function (done) {
-    var app = bootstrap();
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom'
+			})
+			.expect(400, /invalid or missing redirect_uri parameter/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom'
-      })
-      .expect(400, /invalid or missing redirect_uri parameter/i, done);
-  });
+	it('should detect invalid client', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(); // Fake invalid
+			}
+		});
 
-  it('should detect invalid client', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(); // Fake invalid
-      }
-    });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.expect('WWW-Authenticate', 'Basic realm="Service"')
+			.expect(400, /invalid client credentials/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .expect('WWW-Authenticate', 'Basic realm="Service"')
-      .expect(400, /invalid client credentials/i, done);
-  });
+	it('should detect mismatching redirect_uri with a string', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			}
+		});
 
-  it('should detect mismatching redirect_uri with a string', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      }
-    });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://wrong.com'
+			})
+			.expect(400, /redirect_uri does not match/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://wrong.com'
-      })
-      .expect(400, /redirect_uri does not match/i, done);
-  });
+	it('should detect mismatching redirect_uri within an array', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: ['http://nightworld.com', 'http://dayworld.com']
+				});
+			}
+		});
 
-  it('should detect mismatching redirect_uri within an array', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: ['http://nightworld.com','http://dayworld.com']
-        });
-      }
-    });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://wrong.com'
+			})
+			.expect(400, /redirect_uri does not match/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://wrong.com'
-      })
-      .expect(400, /redirect_uri does not match/i, done);
-  });
+	it('should accept a valid redirect_uri within an array', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: ['http://nightworld.com', 'http://dayworld.com']
+				});
+			}
+		});
 
-  it('should accept a valid redirect_uri within an array', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: ['http://nightworld.com','http://dayworld.com']
-        });
-      }
-    });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.expect(302, /Found. Redirecting/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .expect(302, /Found. Redirecting/i, done);
-  });
+	it('should accept a valid redirect_uri with a string', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			}
+		});
 
-  it('should accept a valid redirect_uri with a string', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      }
-    });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.expect(302, /Found. Redirecting/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .expect(302, /Found. Redirecting/i, done);
-  });
+	it('should detect user access denied', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			}
+		}, [false, false]);
 
-  it('should detect user access denied', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      }
-    }, [false, false]);
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.expect(302,
+				/Redirecting to http:\/\/nightworld.com\?error=access_denied/i, done);
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .expect(302,
-        /Redirecting to http:\/\/nightworld.com\?error=access_denied/i, done);
-  });
+	it('should try to save auth code', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAuthCode: function (authCode, clientId, expires, _user, _scope, _callback) {
+				should.exist(authCode);
+				authCode.should.have.lengthOf(40);
+				clientId.should.equal('thom');
+				(+expires).should.be.within(2, (+new Date()) + 30000);
+				done();
+			}
+		}, [false, true]);
 
-  it('should try to save auth code', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
-        should.exist(authCode);
-        authCode.should.have.lengthOf(40);
-        clientId.should.equal('thom');
-        (+expires).should.be.within(2, (+new Date()) + 30000);
-        done();
-      }
-    }, [false, true]);
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.end();
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .end();
-  });
+	it('should return a scope', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAuthCode: function (authCode, clientId, expires, user, scope, _callback) {
+				scope.should.equal('foobar');
+				done();
+			}
+		}, [false, true, false, 'foobar']);
 
-  it('should return a scope', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
-        scope.should.equal('foobar');
-        done();
-      }
-    }, [false, true, false, 'foobar']);
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.end();
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .end();
-  });
+	it('should accept valid request and return code using POST', function (done) {
+		let code;
 
-  it('should accept valid request and return code using POST', function (done) {
-    var code;
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
+				should.exist(authCode);
+				code = authCode;
+				callback();
+			}
+		}, [false, true]);
 
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
-        should.exist(authCode);
-        code = authCode;
-        callback();
-      }
-    }, [false, true]);
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.expect(302, (err, res) => {
+				if (err) {
+					return done(err);
+				}
+				res.header.location.should.equal('http://nightworld.com?code=' + code);
+				done();
+			});
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .expect(302, function (err, res) {
-        res.header.location.should.equal('http://nightworld.com?code=' + code);
-        done();
-      });
-  });
+	it('should accept valid request and return code using GET', function (done) {
+		let code;
 
-  it('should accept valid request and return code using GET', function (done) {
-    var code;
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
+				should.exist(authCode);
+				code = authCode;
+				callback();
+			}
+		}, [false, true]);
 
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
-        should.exist(authCode);
-        code = authCode;
-        callback();
-      }
-    }, [false, true]);
+		request(app)
+			.get('/authorise')
+			.query({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.expect(302, (err, res) => {
+				if (err) {
+					return done(err);
+				}
+				res.header.location.should.equal('http://nightworld.com?code=' + code);
+				done();
+			});
+	});
 
-    request(app)
-      .get('/authorise')
-      .query({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .expect(302, function (err, res) {
-        res.header.location.should.equal('http://nightworld.com?code=' + code);
-        done();
-      });
-  });
+	it('should accept valid request and return code and state using GET', function (done) {
+		let code;
 
-  it('should accept valid request and return code and state using GET', function (done) {
-    var code;
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
+				should.exist(authCode);
+				code = authCode;
+				callback();
+			}
+		}, [false, true]);
 
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
-        should.exist(authCode);
-        code = authCode;
-        callback();
-      }
-    }, [false, true]);
+		request(app)
+			.get('/authorise')
+			.query({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com',
+				state: 'some_state'
+			})
+			.expect(302, (err, res) => {
+				if (err) {
+					return done(err);
+				}
+				res.header.location.should.equal('http://nightworld.com?code=' + code + '&state=some_state');
+				done();
+			});
+	});
 
-    request(app)
-      .get('/authorise')
-      .query({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com',
-        state: 'some_state'
-      })
-      .expect(302, function (err, res) {
-        res.header.location.should.equal('http://nightworld.com?code=' + code  + '&state=some_state');
-        done();
-      });
-  });
+	it('should continue after success response if continueAfterResponse = true', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
+				callback();
+			}
+		}, [false, true], true);
 
-  it('should continue after success response if continueAfterResponse = true', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAuthCode: function (authCode, clientId, expires, user, scope, callback) {
-        callback();
-      }
-    }, [false, true], true);
+		let hit = false;
+		app.all('*', function (_req, _res, _done) {
+			hit = true;
+		});
 
-    var hit = false;
-    app.all('*', function (req, res, done) {
-      hit = true;
-    });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.end(function (err, _res) {
+				if (err) {
+					return done(err);
+				}
+				hit.should.equal(true);
+				done();
+			});
+	});
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .end(function (err, res) {
-        if (err) return done(err);
-        hit.should.equal(true);
-        done();
-      });
-  });
+	it('should continue after redirect response if continueAfterResponse = true', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			}
+		}, [false, false], true);
 
-  it('should continue after redirect response if continueAfterResponse = true', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      }
-    }, [false, false], true);
+		let hit = false;
+		app.all('*', function (_req, _res, _done) {
+			hit = true;
+		});
 
-    var hit = false;
-    app.all('*', function (req, res, done) {
-      hit = true;
-    });
-
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'code',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .end(function (err, res) {
-        if (err) return done(err);
-        hit.should.equal(true);
-        done();
-      });
-  });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'code',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.end(function (err, _res) {
+				if (err) {
+					return done(err);
+				}
+				hit.should.equal(true);
+				done();
+			});
+	});
 
 });

--- a/test/authorise.test.js
+++ b/test/authorise.test.js
@@ -13,235 +13,234 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (model, options, continueAfterResponse) {
-  var app = express();
+function bootstrap(model, options, continueAfterResponse) {
+	const app = express();
 
-  model = model || {
-    getAccessToken: function (token, callback) {
-      var expires = new Date(Date.now() * 2);
+	model = model || {
+		getAccessToken: function (token, callback) {
+			const expires = new Date(Date.now() * 2);
 
-      callback(false, { expires: expires });
-    },
-    authoriseScope: function (accessToken, scope, cb) {
-      cb(false, false);
-    }
-  };
+			callback(false, { expires: expires });
+		},
+		authoriseScope: function (accessToken, scope, cb) {
+			cb(false, false);
+		}
+	};
 
-  app.oauth = oauth2server({
-    model: model || {},
-    continueAfterResponse: continueAfterResponse
-  });
+	app.oauth = oauth2server({
+		model: model || {},
+		continueAfterResponse: continueAfterResponse
+	});
 
-  app.use(bodyParser());
+	app.use(bodyParser());
 
-  app.get('/', app.oauth.authorise(options), function (req, res) {
-    res.send('nightworld');
-  });
+	app.get('/', app.oauth.authorise(options), function (req, res) {
+		res.send('nightworld');
+	});
 
-  app.post('/', app.oauth.authorise(options), function (req, res) {
-    res.send('nightworld');
-  });
+	app.post('/', app.oauth.authorise(options), function (req, res) {
+		res.send('nightworld');
+	});
 
-  app.use(app.oauth.errorHandler());
+	app.use(app.oauth.errorHandler());
 
-  return app;
+	return app;
 };
 
 describe('Authorise', function () {
+	it('should detect no access token', function (done) {
+		const app = bootstrap();
 
-  it('should detect no access token', function (done) {
-    var app = bootstrap();
+		request(app)
+			.get('/')
+			.expect(400, /the access token was not found/i, done);
+	});
 
-    request(app)
-      .get('/')
-      .expect(400, /the access token was not found/i, done);
-  });
+	it('should allow valid token as query param', function (done){
+		const app = bootstrap();
 
-  it('should allow valid token as query param', function (done){
-    var app = bootstrap();
+		request(app)
+			.get('/?access_token=thom')
+			.expect(200, /nightworld/, done);
+	});
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(200, /nightworld/, done);
-  });
-
-  it('should require application/x-www-form-urlencoded when access token is ' +
+	it('should require application/x-www-form-urlencoded when access token is ' +
       'in body', function (done) {
-    var app = bootstrap();
+		const app = bootstrap();
 
-    request(app)
-      .post('/')
-      .send({ access_token: 'thom' })
-      .expect(400, /content type must be application\/x-www-form-urlencoded/i,
-        done);
-  });
+		request(app)
+			.post('/')
+			.send({ access_token: 'thom' })
+			.expect(400, /content type must be application\/x-www-form-urlencoded/i,
+				done);
+	});
 
-  it('should not allow GET when access token in body', function (done) {
-    var app = bootstrap();
+	it('should not allow GET when access token in body', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .get('/')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({ access_token: 'thom' })
-      .expect(400, /method cannot be GET/i, done);
-  });
+		request(app)
+			.get('/')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({ access_token: 'thom' })
+			.expect(400, /method cannot be GET/i, done);
+	});
 
-  it('should allow valid token in body', function (done){
-    var app = bootstrap();
+	it('should allow valid token in body', function (done){
+		const app = bootstrap();
 
-    request(app)
-      .post('/')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({ access_token: 'thom' })
-      .expect(200, /nightworld/, done);
-  });
+		request(app)
+			.post('/')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({ access_token: 'thom' })
+			.expect(200, /nightworld/, done);
+	});
 
-  it('should allow if scope is valid for the token', function (done) {
-    var app = bootstrap(null, { scope: 'foobar' });
+	it('should allow if scope is valid for the token', function (done) {
+		const app = bootstrap(null, { scope: 'foobar' });
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(200, /nightworld/, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.expect(200, /nightworld/, done);
+	});
 
-  it('should not allow if scope is invalid for the token', function (done) {
-    var app = bootstrap({
-      getAccessToken: function (token, callback) {
-        callback(false, { expires: null });
-      },
-      authoriseScope: function (accessToken, scope, cb) {
-        cb(false, true);
-      }
-    }, { scope: 'foobar' });
+	it('should not allow if scope is invalid for the token', function (done) {
+		const app = bootstrap({
+			getAccessToken: function (token, callback) {
+				callback(false, { expires: null });
+			},
+			authoriseScope: function (accessToken, scope, cb) {
+				cb(false, true);
+			}
+		}, { scope: 'foobar' });
 
-    app.use(app.oauth.errorHandler());
+		app.use(app.oauth.errorHandler());
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(400, /invalid_scope/, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.expect(400, /invalid_scope/, done);
+	});
 
-  it('should detect malformed header', function (done) {
-    var app = bootstrap();
+	it('should detect malformed header', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .get('/')
-      .set('Authorization', 'Invalid')
-      .expect(400, /malformed auth header/i, done);
-  });
+		request(app)
+			.get('/')
+			.set('Authorization', 'Invalid')
+			.expect(400, /malformed auth header/i, done);
+	});
 
-  it('should allow valid token in header', function (done){
-    var app = bootstrap();
+	it('should allow valid token in header', function (done){
+		const app = bootstrap();
 
-    request(app)
-      .get('/')
-      .set('Authorization', 'Bearer thom')
-      .expect(200, /nightworld/, done);
-  });
+		request(app)
+			.get('/')
+			.set('Authorization', 'Bearer thom')
+			.expect(200, /nightworld/, done);
+	});
 
-  it('should allow exactly one method (get: query + auth)', function (done) {
-    var app = bootstrap();
+	it('should allow exactly one method (get: query + auth)', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .get('/?access_token=thom')
-      .set('Authorization', 'Invalid')
-      .expect(400, /only one method may be used/i, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.set('Authorization', 'Invalid')
+			.expect(400, /only one method may be used/i, done);
+	});
 
-  it('should allow exactly one method (post: query + body)', function (done) {
-    var app = bootstrap();
+	it('should allow exactly one method (post: query + body)', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .post('/?access_token=thom')
-      .send({
-        access_token: 'thom'
-      })
-      .expect(400, /only one method may be used/i, done);
-  });
+		request(app)
+			.post('/?access_token=thom')
+			.send({
+				access_token: 'thom'
+			})
+			.expect(400, /only one method may be used/i, done);
+	});
 
-  it('should allow exactly one method (post: query + empty body)', function (done) {
-    var app = bootstrap();
+	it('should allow exactly one method (post: query + empty body)', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .post('/?access_token=thom')
-      .send({
-        access_token: ''
-      })
-      .expect(400, /only one method may be used/i, done);
-  });
+		request(app)
+			.post('/?access_token=thom')
+			.send({
+				access_token: ''
+			})
+			.expect(400, /only one method may be used/i, done);
+	});
 
-  it('should detect expired token', function (done){
-    var app = bootstrap({
-      getAccessToken: function (token, callback) {
-        callback(false, { expires: 0 }); // Fake expires
-      }
-    });
+	it('should detect expired token', function (done){
+		const app = bootstrap({
+			getAccessToken: function (token, callback) {
+				callback(false, { expires: 0 }); // Fake expires
+			}
+		});
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(401, /the access token provided has expired/i, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.expect(401, /the access token provided has expired/i, done);
+	});
 
-  it('should passthrough with valid, non-expiring token (token = null)', function (done) {
-    var app = bootstrap({
-      getAccessToken: function (token, callback) {
-        callback(false, { expires: null });
-      }
-    }, false);
+	it('should passthrough with valid, non-expiring token (token = null)', function (done) {
+		const app = bootstrap({
+			getAccessToken: function (token, callback) {
+				callback(false, { expires: null });
+			}
+		}, false);
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(200, /nightworld/, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.expect(200, /nightworld/, done);
+	});
 
-  it('should expose the user id when setting userId', function (done) {
-    var app = bootstrap({
-      getAccessToken: function (token, callback) {
-        var expires = new Date(Date.now() * 2);
+	it('should expose the user id when setting userId', function (done) {
+		const app = bootstrap({
+			getAccessToken: function (token, callback) {
+				const expires = new Date(Date.now() * 2);
 
-        callback(false, { expires: expires , userId: 1 });
-      }
-    });
+				callback(false, { expires: expires , userId: 1 });
+			}
+		});
 
-    app.get('/', function (req, res) {
-      req.should.have.property('user');
-      req.user.should.have.property('id');
-      req.user.id.should.equal(1);
-    });
+		app.get('/', function (req, _res) {
+			req.should.have.property('user');
+			req.user.should.have.property('id');
+			req.user.id.should.equal(1);
+		});
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(200, /nightworld/, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.expect(200, /nightworld/, done);
+	});
 
-  it('should expose the user id when setting user object', function (done) {
-    var app = bootstrap({
-      getAccessToken: function (token, callback) {
-        var expires = new Date(Date.now() * 2);
+	it('should expose the user id when setting user object', function (done) {
+		const app = bootstrap({
+			getAccessToken: function (token, callback) {
+				const expires = new Date(Date.now() * 2);
 
-        callback(false, { expires: expires, user: { id: 1, name: 'thom' }});
-      }
-    });
+				callback(false, { expires: expires, user: { id: 1, name: 'thom' } });
+			}
+		});
 
-    app.get('/', function (req, res) {
-      req.should.have.property('user');
-      req.user.should.have.property('id');
-      req.user.id.should.equal(1);
-      req.user.should.have.property('name');
-      req.user.name.should.equal('thom');
-    });
+		app.get('/', function (req, _res) {
+			req.should.have.property('user');
+			req.user.should.have.property('id');
+			req.user.id.should.equal(1);
+			req.user.should.have.property('name');
+			req.user.name.should.equal('thom');
+		});
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(200, /nightworld/, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.expect(200, /nightworld/, done);
+	});
 
 });

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,111 +1,110 @@
-var should = require('should');
+'use strict';
 
-var OAuth2Error = require('../lib/error');
+const OAuth2Error = require('../lib/error');
 
 describe('OAuth2Error', function() {
+	it('should be an instance of `Error`', function () {
+		const error = new OAuth2Error('invalid_request', 'The access token was not found');
 
-  it('should be an instance of `Error`', function () {
-    var error = new OAuth2Error('invalid_request', 'The access token was not found');
+		error.should.be.instanceOf(Error);
+	});
 
-    error.should.be.instanceOf(Error);
-  });
+	it('should expose the `message` as the description', function () {
+		const error = new OAuth2Error('invalid_request', 'The access token was not found');
 
-  it('should expose the `message` as the description', function () {
-    var error = new OAuth2Error('invalid_request', 'The access token was not found');
+		error.message.should.equal('The access token was not found');
+	});
 
-    error.message.should.equal('The access token was not found');
-  });
+	it('should expose the `stack`', function () {
+		const error = new OAuth2Error('invalid_request', 'The access token was not found');
 
-  it('should expose the `stack`', function () {
-    var error = new OAuth2Error('invalid_request', 'The access token was not found');
+		error.stack.should.not.equal(undefined);
+	});
 
-    error.stack.should.not.equal(undefined);
-  });
+	it('should expose a custom `name`', function () {
+		const error = new OAuth2Error();
 
-  it('should expose a custom `name`', function () {
-    var error = new OAuth2Error();
+		error.name.should.equal('OAuth2Error');
+	});
 
-    error.name.should.equal('OAuth2Error');
-  });
+	it('should set cache `headers`', function () {
+		const error = new OAuth2Error('invalid_request');
 
-  it('should set cache `headers`', function () {
-    var error = new OAuth2Error('invalid_request');
+		error.headers.should.eql({
+			'Cache-Control': 'no-store',
+			'Pragma': 'no-cache'
+		});
+	});
 
-    error.headers.should.eql({
-      'Cache-Control': 'no-store',
-      'Pragma': 'no-cache'
-    });
-  });
+	it('should include WWW-Authenticate `header` if error is `invalid_client`', function () {
+		const error = new OAuth2Error('invalid_client');
 
-  it('should include WWW-Authenticate `header` if error is `invalid_client`', function () {
-    var error = new OAuth2Error('invalid_client');
+		error.headers.should.eql({
+			'Cache-Control': 'no-store',
+			'Pragma': 'no-cache',
+			'WWW-Authenticate': 'Basic realm="Service"'
+		});
+	});
 
-    error.headers.should.eql({
-      'Cache-Control': 'no-store',
-      'Pragma': 'no-cache',
-      'WWW-Authenticate': 'Basic realm="Service"'
-    });
-  });
+	it('should expose a status `code`', function () {
+		const error = new OAuth2Error('invalid_client');
 
-  it('should expose a status `code`', function () {
-    var error = new OAuth2Error('invalid_client');
+		error.code.should.be.instanceOf(Number);
+	});
 
-    error.code.should.be.instanceOf(Number);
-  });
+	it('should expose the `error`', function () {
+		const error = new OAuth2Error('invalid_client');
 
-  it('should expose the `error`', function () {
-    var error = new OAuth2Error('invalid_client');
+		error.error.should.equal('invalid_client');
+	});
 
-    error.error.should.equal('invalid_client');
-  });
+	it('should expose the `error_description`', function () {
+		const error = new OAuth2Error('invalid_client', 'The access token was not found');
 
-  it('should expose the `error_description`', function () {
-    var error = new OAuth2Error('invalid_client', 'The access token was not found');
+		error.error_description.should.equal('The access token was not found');
+	});
 
-    error.error_description.should.equal('The access token was not found');
-  });
+	it('should expose the `stack` of a previous error', function () {
+		const error = new OAuth2Error('invalid_request', 'The access token was not found', new Error());
 
-  it('should expose the `stack` of a previous error', function () {
-    var error = new OAuth2Error('invalid_request', 'The access token was not found', new Error());
+		error.stack.should.not.match(/^OAuth2Error/);
+		error.stack.should.match(/^Error/);
+	});
 
-    error.stack.should.not.match(/^OAuth2Error/);
-    error.stack.should.match(/^Error/);
-  });
+	it('should expose the `message` of a previous error', function () {
+		const error = new OAuth2Error('invalid_request', 'The access token was not found', new Error('foo'));
 
-  it('should expose the `message` of a previous error', function () {
-    var error = new OAuth2Error('invalid_request', 'The access token was not found', new Error('foo'));
-
-    error.message.should.equal('foo');
-  });
+		error.message.should.equal('foo');
+	});
 
 
-  it('should expose the `mfa_token` when passed in mfa_required', function () {
-      var error = new OAuth2Error('mfa_required', 'mfatokenhere');
+	it('should expose the `mfa_token` when passed in mfa_required', function () {
+		const error = new OAuth2Error('mfa_required', 'mfatokenhere');
 
-      error.mfa_token.should.equal('mfatokenhere');
-  });
+		error.mfa_token.should.equal('mfatokenhere');
+	});
 
-  it('should set the message correctly for mfa_required', function () {
-      var error = new OAuth2Error('mfa_required', 'mfatokenhere');
+	it('should set the message correctly for mfa_required', function () {
+		const error = new OAuth2Error('mfa_required', 'mfatokenhere');
 
-      error.error_description.should.equal('Multi-factor authentication required');
-  });
+		error.error_description.should.equal('Multi-factor authentication required');
+	});
 
-  it('should set the code correctly for mfa_required', function () {
-      var error = new OAuth2Error('mfa_required', 'mfatokenhere');
+	it('should set the code correctly for mfa_required', function () {
+		const error = new OAuth2Error('mfa_required', 'mfatokenhere');
 
-      error.code.should.equal(403);
-  });
+		error.code.should.equal(403);
+	});
 
-  it('should expose the right status `code` for rate_limit_exceeded', function () {
-    var error = new OAuth2Error('rate_limit_exceeded');
+	it('should expose the right status `code` for rate_limit_exceeded', function () {
+		const error = new OAuth2Error('rate_limit_exceeded');
 
-    error.code.should.equal(429);
-  });
+		error.code.should.equal(429);
+	});
 
-  it('should expose the right status `code` for demo_read_only', function () {
-    var error = new OAuth2Error('demo_read_only');
+	it('should expose the right status `code` for demo_read_only', function () {
+		const error = new OAuth2Error('demo_read_only');
 
-    error.code.should.equal(403);
-  });
+		error.code.should.equal(403);
+	});
 });

--- a/test/errorHandler.test.js
+++ b/test/errorHandler.test.js
@@ -13,74 +13,76 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (oauthConfig) {
-  var app = express(),
-    oauth = oauth2server(oauthConfig || { model: {} });
+function bootstrap(oauthConfig) {
+	const app = express(),
+		oauth = oauth2server(oauthConfig || { model: {} });
 
-  app.use(bodyParser());
+	app.use(bodyParser());
 
-  app.all('/oauth/token', oauth.grant());
-  app.all('/', oauth.authorise(), function (req, res) {
-    res.send('Hello World');
-  });
+	app.all('/oauth/token', oauth.grant());
+	app.all('/', oauth.authorise(), function (req, res) {
+		res.send('Hello World');
+	});
 
-  app.use(oauth.errorHandler());
-  if (oauthConfig && oauthConfig.passthroughErrors) {
-    app.use(function (err, req, res, next) {
-      res.send('passthrough');
-    });
-  }
+	app.use(oauth.errorHandler());
+	if (oauthConfig && oauthConfig.passthroughErrors) {
+		app.use((_err, _req, res, _next) => {
+			res.send('passthrough');
+		});
+	}
 
-  return app;
-};
+	return app;
+}
 
-describe('Error Handler', function() {
-  it('should return an oauth conformat response', function (done) {
-    var app = bootstrap();
+describe('Error Handler', function () {
+	it('should return an oauth conformat response', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .get('/')
-      .expect(400)
-      .end(function (err, res) {
-        if (err) return done(err);
+		request(app)
+			.get('/')
+			.expect(400)
+			.end(function (err, res) {
+				if (err) {
+					return done(err);
+				}
 
-        res.body.should.have.keys('error', 'error_description');
+				res.body.should.have.keys('error', 'error_description');
 
-        res.body.error.should.be.instanceOf(String);
+				res.body.error.should.be.instanceOf(String);
 
-        res.body.error_description.should.be.instanceOf(String);
+				res.body.error_description.should.be.instanceOf(String);
 
-        done();
-      });
-  });
+				done();
+			});
+	});
 
-  it('should passthrough authorise errors', function (done) {
-    var app = bootstrap({
-      passthroughErrors: true,
-      model: {}
-    });
+	it('should passthrough authorise errors', function (done) {
+		const app = bootstrap({
+			passthroughErrors: true,
+			model: {}
+		});
 
-    request(app)
-      .get('/')
-      .expect(200, /^passthrough$/, done);
-  });
+		request(app)
+			.get('/')
+			.expect(200, /^passthrough$/, done);
+	});
 
-  it('should passthrough grant errors', function (done) {
-    var app = bootstrap({
-      passthroughErrors: true,
-      model: {}
-    });
+	it('should passthrough grant errors', function (done) {
+		const app = bootstrap({
+			passthroughErrors: true,
+			model: {}
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .expect(200, /^passthrough$/, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.expect(200, /^passthrough$/, done);
+	});
 });

--- a/test/grant.authorization_code.test.js
+++ b/test/grant.authorization_code.test.js
@@ -13,220 +13,220 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (oauthConfig) {
-  var app = express(),
-    oauth = oauth2server(oauthConfig || {
-      model: {},
-      grants: ['password', 'refresh_token']
-    });
+function bootstrap(oauthConfig) {
+	const app = express(),
+		oauth = oauth2server(oauthConfig || {
+			model: {},
+			grants: ['password', 'refresh_token']
+		});
 
-  app.set('json spaces', 0);
-  app.use(bodyParser());
+	app.set('json spaces', 0);
+	app.use(bodyParser());
 
-  app.all('/oauth/token', oauth.grant());
+	app.all('/oauth/token', oauth.grant());
 
-  app.use(oauth.errorHandler());
+	app.use(oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
 describe('Granting with authorization_code grant type', function () {
-  it('should detect missing parameters', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        }
-      },
-      grants: ['authorization_code']
-    });
+	it('should detect missing parameters', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				}
+			},
+			grants: ['authorization_code']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'authorization_code',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /no \\"code\\" parameter/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'authorization_code',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /no \\"code\\" parameter/i, done);
 
-  });
+	});
 
-  it('should invalid authorization_code', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getAuthCode: function (code, callback) {
-          callback(false); // Fake invalid
-        }
-      },
-      grants: ['authorization_code']
-    });
+	it('should invalid authorization_code', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getAuthCode: function (code, callback) {
+					callback(false); // Fake invalid
+				}
+			},
+			grants: ['authorization_code']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'authorization_code',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        code: 'abc123'
-      })
-      .expect(400, /invalid code/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'authorization_code',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				code: 'abc123'
+			})
+			.expect(400, /invalid code/i, done);
+	});
 
-  it('should detect invalid client_id', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getAuthCode: function (code, callback) {
-          callback(false, { clientId: 'wrong' });
-        }
-      },
-      grants: ['authorization_code']
-    });
+	it('should detect invalid client_id', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getAuthCode: function (code, callback) {
+					callback(false, { clientId: 'wrong' });
+				}
+			},
+			grants: ['authorization_code']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'authorization_code',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        code: 'abc123'
-      })
-      .expect(400, /invalid code/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'authorization_code',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				code: 'abc123'
+			})
+			.expect(400, /invalid code/i, done);
+	});
 
-  it('should detect expired code', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: 'thom' });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getAuthCode: function (data, callback) {
-          callback(false, {
-            clientId: 'thom',
-            expires: new Date(+new Date() - 60)
-          });
-        }
-      },
-      grants: ['authorization_code']
-    });
+	it('should detect expired code', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: 'thom' });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getAuthCode: function (data, callback) {
+					callback(false, {
+						clientId: 'thom',
+						expires: new Date(+new Date() - 60)
+					});
+				}
+			},
+			grants: ['authorization_code']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'authorization_code',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        code: 'abc123'
-      })
-      .expect(400, /code has expired/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'authorization_code',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				code: 'abc123'
+			})
+			.expect(400, /code has expired/i, done);
+	});
 
-  it('should require code expiration', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: 'thom' });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getAuthCode: function (data, callback) {
-          callback(false, {
-            clientId: 'thom',
-            expires: null // This is invalid
-          });
-        }
-      },
-      grants: ['authorization_code']
-    });
+	it('should require code expiration', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: 'thom' });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getAuthCode: function (data, callback) {
+					callback(false, {
+						clientId: 'thom',
+						expires: null // This is invalid
+					});
+				}
+			},
+			grants: ['authorization_code']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'authorization_code',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        code: 'abc123'
-      })
-      .expect(400, /code has expired/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'authorization_code',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				code: 'abc123'
+			})
+			.expect(400, /code has expired/i, done);
+	});
 
 
-  it('should allow valid request', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: 'thom' });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getAuthCode: function (refreshToken, callback) {
-          refreshToken.should.equal('abc123');
-          callback(false, {
-            clientId: 'thom',
-            expires: new Date(),
-            userId: '123',
-            scope: 'foobar'
-          });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        saveRefreshToken: function (data, cb) {
-          cb();
-        },
-        expireRefreshToken: function (refreshToken, callback) {
-          callback();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(null, 'foobar', false);
-        }
-      },
-      grants: ['authorization_code']
-    });
+	it('should allow valid request', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: 'thom' });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getAuthCode: function (refreshToken, callback) {
+					refreshToken.should.equal('abc123');
+					callback(false, {
+						clientId: 'thom',
+						expires: new Date(),
+						userId: '123',
+						scope: 'foobar'
+					});
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				saveRefreshToken: function (data, cb) {
+					cb();
+				},
+				expireRefreshToken: function (refreshToken, callback) {
+					callback();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(null, 'foobar', false);
+				}
+			},
+			grants: ['authorization_code']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'authorization_code',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        code: 'abc123'
-      })
-      .expect(200, /"access_token":"(.*)"/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'authorization_code',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				code: 'abc123'
+			})
+			.expect(200, /"access_token":"(.*)"/i, done);
+	});
 
 });

--- a/test/grant.client_credentials.test.js
+++ b/test/grant.client_credentials.test.js
@@ -13,96 +13,94 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (oauthConfig) {
-  var app = express(),
-    oauth = oauth2server(oauthConfig || {
-      model: {},
-      grants: ['client_credentials']
-    });
+function bootstrap(oauthConfig) {
+	const app = express(),
+		oauth = oauth2server(oauthConfig || {
+			model: {},
+			grants: ['client_credentials']
+		});
 
-  app.set('json spaces', 0);
-  app.use(bodyParser());
+	app.set('json spaces', 0);
+	app.use(bodyParser());
 
-  app.all('/oauth/token', oauth.grant());
+	app.all('/oauth/token', oauth.grant());
 
-  app.use(oauth.errorHandler());
+	app.use(oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
 describe('Granting with client_credentials grant type', function () {
+	// N.B. Client is authenticated earlier in request
+	it('should detect invalid user', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: id });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getUserFromClient: function (client, callback) {
+					client.clientId.should.equal('thom');
+					client.clientSecret.should.equal('nightworld');
+					callback(false, false); // Fake invalid user
+				}
+			},
+			grants: ['client_credentials']
+		});
 
-  // N.B. Client is authenticated earlier in request
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'client_credentials'
+			})
+			.set('Authorization', 'Basic dGhvbTpuaWdodHdvcmxk')
+			.expect(400, /client credentials are invalid/i, done);
 
-  it('should detect invalid user', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: id });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getUserFromClient: function (client, callback) {
-          client.clientId.should.equal('thom');
-          client.clientSecret.should.equal('nightworld');
-          callback(false, false); // Fake invalid user
-        }
-      },
-      grants: ['client_credentials']
-    });
+	});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'client_credentials'
-      })
-      .set('Authorization', 'Basic dGhvbTpuaWdodHdvcmxk')
-      .expect(400, /client credentials are invalid/i, done);
+	it('should bypass the MFA check', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: id });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getUserFromClient: function (client, callback) {
+					client.clientId.should.equal('thom');
+					client.clientSecret.should.equal('nightworld');
+					callback(false, { id: 1, mfaEnabled: true });
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+			},
+			grants: ['client_credentials']
+		});
 
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'client_credentials'
+			})
+			.set('Authorization', 'Basic dGhvbTpuaWdodHdvcmxk')
+			.expect(200, /"access_token":"(.*)",(.*)"/i, done);
 
-it('should bypass the MFA check', function (done) {
-  var app = bootstrap({
-    model: {
-      getClient: function (id, secret, callback) {
-        callback(false, { clientId: id });
-      },
-      grantTypeAllowed: function (clientId, grantType, callback) {
-        callback(false, true);
-      },
-      getUserFromClient: function (client, callback) {
-        client.clientId.should.equal('thom');
-        client.clientSecret.should.equal('nightworld');
-        callback(false, { id: 1, mfaEnabled: true });
-      },
-      validateScope: function (scope, client, user, cb) {
-        cb(false, '', false);
-      },
-      saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-        cb();
-      },
-    },
-    grants: ['client_credentials']
-  });
-
-  request(app)
-    .post('/oauth/token')
-    .set('Content-Type', 'application/x-www-form-urlencoded')
-    .send({
-      grant_type: 'client_credentials'
-    })
-    .set('Authorization', 'Basic dGhvbTpuaWdodHdvcmxk')
-    .expect(200, /"access_token":"(.*)",(.*)"/i, done);
-
-  });
+	});
 });

--- a/test/grant.demo_account.test.js
+++ b/test/grant.demo_account.test.js
@@ -54,7 +54,7 @@ function validModel(overrides) {
 
 const minimalModel = {
 	getClient: (id, secret, cb) => {
-		cb(null, true);
+		cb(null, {});
 	},
 	grantTypeAllowed: (clientId, grantType, cb) => {
 		cb(null, true);
@@ -139,7 +139,9 @@ describe('Granting with demo_account grant type', () => {
 
 	it('should not include a refresh_token in the response', async () => {
 		const app = bootstrap(
-			{ ...validModel(), saveRefreshToken: (token, clientId, expires, user, cb) => { cb(); } },
+			{ ...validModel(), saveRefreshToken: (token, clientId, expires, user, cb) => {
+				cb();
+			} },
 			['urn:custom:demo_account', 'refresh_token']
 		);
 

--- a/test/grant.extended.test.js
+++ b/test/grant.extended.test.js
@@ -13,175 +13,175 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (oauthConfig) {
-  var app = express(),
-    oauth = oauth2server(oauthConfig || {
-      model: {},
-      grants: ['password', 'refresh_token']
-    });
+function bootstrap(oauthConfig) {
+	const app = express(),
+		oauth = oauth2server(oauthConfig || {
+			model: {},
+			grants: ['password', 'refresh_token']
+		});
 
-  app.set('json spaces', 0);
-  app.use(bodyParser());
+	app.set('json spaces', 0);
+	app.use(bodyParser());
 
-  app.all('/oauth/token', oauth.grant());
+	app.all('/oauth/token', oauth.grant());
 
-  app.use(oauth.errorHandler());
+	app.use(oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
 describe('Granting with extended grant type', function () {
-  it('should ignore if no extendedGrant method', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        }
-      },
-      grants: ['http://custom.com']
-    });
+	it('should ignore if no extendedGrant method', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				}
+			},
+			grants: ['http://custom.com']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'http://custom.com',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /invalid grant_type/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'http://custom.com',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /invalid grant_type/i, done);
+	});
 
-  it('should still detect unsupported grant_type', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        extendedGrant: function (grantType, req, callback) {
-          callback(false, false);
-        }
-      },
-      grants: ['http://custom.com']
-    });
+	it('should still detect unsupported grant_type', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				extendedGrant: function (grantType, req, callback) {
+					callback(false, false);
+				}
+			},
+			grants: ['http://custom.com']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'http://custom.com',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /invalid grant_type/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'http://custom.com',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /invalid grant_type/i, done);
+	});
 
-  it('should require a user.id', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        extendedGrant: function (grantType, req, callback) {
-          callback(false, true, {}); // Fake empty user
-        }
-      },
-      grants: ['http://custom.com']
-    });
+	it('should require a user.id', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				extendedGrant: function (grantType, req, callback) {
+					callback(false, true, {}); // Fake empty user
+				}
+			},
+			grants: ['http://custom.com']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'http://custom.com',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /invalid request/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'http://custom.com',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /invalid request/i, done);
+	});
 
-  it('should passthrough valid request', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: 'thom', clientSecret: 'nightworld' });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        extendedGrant: function (grantType, req, callback) {
-          req.oauth.client.clientId.should.equal('thom');
-          req.oauth.client.clientSecret.should.equal('nightworld');
-          callback(false, true, { id: 3 });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        }
-      },
-      grants: ['http://custom.com']
-    });
+	it('should passthrough valid request', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: 'thom', clientSecret: 'nightworld' });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				extendedGrant: function (grantType, req, callback) {
+					req.oauth.client.clientId.should.equal('thom');
+					req.oauth.client.clientSecret.should.equal('nightworld');
+					callback(false, true, { id: 3 });
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				}
+			},
+			grants: ['http://custom.com']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'http://custom.com',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(200, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'http://custom.com',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(200, done);
+	});
 
-  it('should allow any valid URI valid request', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        extendedGrant: function (grantType, req, callback) {
-          callback(false, true, { id: 3 });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        }
-      },
-      grants: ['urn:custom:grant']
-    });
+	it('should allow any valid URI valid request', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				extendedGrant: function (grantType, req, callback) {
+					callback(false, true, { id: 3 });
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				}
+			},
+			grants: ['urn:custom:grant']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'urn:custom:grant',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(200, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'urn:custom:grant',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(200, done);
+	});
 });

--- a/test/grant.mfaOtp.test.js
+++ b/test/grant.mfaOtp.test.js
@@ -1,223 +1,224 @@
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should'),
-  OAuth2Error = require('../lib/error');
+'use strict';
 
-var oauth2server = require('../');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest'),
+	OAuth2Error = require('../lib/error');
 
-var bootstrap = function (oauthConfig) {
-  var app = express(),
-    oauth = oauth2server(oauthConfig || {
-      model: {},
-      grants: ['password', 'refresh_token', 'urn:custom:mfa-otp']
-    });
+const oauth2server = require('../');
 
-  app.set('json spaces', 0);
-  app.use(bodyParser());
+function bootstrap(oauthConfig) {
+	const app = express(),
+		oauth = oauth2server(oauthConfig || {
+			model: {},
+			grants: ['password', 'refresh_token', 'urn:custom:mfa-otp']
+		});
 
-  app.all('/oauth/token', oauth.grant());
+	app.set('json spaces', 0);
+	app.use(bodyParser());
 
-  app.use(oauth.errorHandler());
+	app.all('/oauth/token', oauth.grant());
 
-  return app;
-};
+	app.use(oauth.errorHandler());
+
+	return app;
+}
 
 describe('Granting with mfa-otp grant type', function () {
-  it('should still detect unsupported grant_type', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        extendedGrant: function (grantType, req, callback) {
-          callback(false, false);
-        }
-      },
-      grants: ['http://custom.com']
-    });
+	it('should still detect unsupported grant_type', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				extendedGrant: function (grantType, req, callback) {
+					callback(false, false);
+				}
+			},
+			grants: ['http://custom.com']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'http://custom.com',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /invalid grant_type/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'http://custom.com',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /invalid grant_type/i, done);
+	});
 
-  it('should require an mfa_token', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        }
-      },
-      grants: ['urn:custom:mfa-otp']
-    });
+	it('should require an mfa_token', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				}
+			},
+			grants: ['urn:custom:mfa-otp']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'urn:custom:mfa-otp',
-        otp: '123456',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /You must provide otp and mfa token/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'urn:custom:mfa-otp',
+				otp: '123456',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /You must provide otp and mfa token/i, done);
+	});
 
-  it('should require an otp', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        }
-      },
-      grants: ['urn:custom:mfa-otp']
-    });
+	it('should require an otp', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				}
+			},
+			grants: ['urn:custom:mfa-otp']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'urn:custom:mfa-otp',
-        mfa_token: '123456',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /You must provide otp and mfa token/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'urn:custom:mfa-otp',
+				mfa_token: '123456',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /You must provide otp and mfa token/i, done);
+	});
 
-  it('should return error from performMfaOtp', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, cb) {
-          cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
-        },
-        grantTypeAllowed: function (clientId, grantType, cb) {
-          cb(false, true);
-        },
-        useMfaOtpGrant: function (grantType, req, cb) {
-          req.oauth.client.clientId.should.equal('thom');
-          req.oauth.client.clientSecret.should.equal('nightworld');
-          cb(false, true, { id: 3 });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        },
-        performMfaOtp: function (req, cb) {
-          cb(new OAuth2Error('invalid_token', 'Could not validate OTP.'));
-        }
-      },
-      grants: ['urn:custom:mfa-otp']
-    });
+	it('should return error from performMfaOtp', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, cb) {
+					cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
+				},
+				grantTypeAllowed: function (clientId, grantType, cb) {
+					cb(false, true);
+				},
+				useMfaOtpGrant: function (grantType, req, cb) {
+					req.oauth.client.clientId.should.equal('thom');
+					req.oauth.client.clientSecret.should.equal('nightworld');
+					cb(false, true, { id: 3 });
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				},
+				performMfaOtp: function (req, cb) {
+					cb(new OAuth2Error('invalid_token', 'Could not validate OTP.'));
+				}
+			},
+			grants: ['urn:custom:mfa-otp']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'urn:custom:mfa-otp',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        mfa_token: '123456',
-        otp: '123456'
-      })
-      .expect(401, /Could not validate OTP/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'urn:custom:mfa-otp',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				mfa_token: '123456',
+				otp: '123456'
+			})
+			.expect(401, /Could not validate OTP/i, done);
+	});
 
-  it('should passthrough valid request', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, cb) {
-          cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
-        },
-        grantTypeAllowed: function (clientId, grantType, cb) {
-          cb(false, true);
-        },
-        useMfaOtpGrant: function (grantType, req, cb) {
-          req.oauth.client.clientId.should.equal('thom');
-          req.oauth.client.clientSecret.should.equal('nightworld');
-          cb(false, true, { id: 3 });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        },
-        performMfaOtp: function (req, cb) {
-          cb(false, true, { id: 3 });
-        }
-      },
-      grants: ['urn:custom:mfa-otp']
-    });
+	it('should passthrough valid request', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, cb) {
+					cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
+				},
+				grantTypeAllowed: function (clientId, grantType, cb) {
+					cb(false, true);
+				},
+				useMfaOtpGrant: function (grantType, req, cb) {
+					req.oauth.client.clientId.should.equal('thom');
+					req.oauth.client.clientSecret.should.equal('nightworld');
+					cb(false, true, { id: 3 });
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				},
+				performMfaOtp: function (req, cb) {
+					cb(false, true, { id: 3 });
+				}
+			},
+			grants: ['urn:custom:mfa-otp']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'urn:custom:mfa-otp',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        mfa_token: '123456',
-        otp: '123456'
-      })
-      .expect(200, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'urn:custom:mfa-otp',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				mfa_token: '123456',
+				otp: '123456'
+			})
+			.expect(200, done);
+	});
 
-  it('should return the rate_limit error', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, cb) {
-        cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
-       },
-        grantTypeAllowed: function (clientId, grantType, cb) {
-          cb(false, true);
-        },
-        useMfaOtpGrant: function (grantType, req, cb) {
-          req.oauth.client.clientId.should.equal('thom');
-          req.oauth.client.clientSecret.should.equal('nightworld');
-          cb(false, true, { id: 3 });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        },
-        performMfaOtp: function (req, cb) {
-          cb(new OAuth2Error('rate_limit_exceeded', 'Rate limit exceeded.'));
-        }
-      },
-      grants: ['urn:custom:mfa-otp']
-    });
+	it('should return the rate_limit error', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, cb) {
+					cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
+				},
+				grantTypeAllowed: function (clientId, grantType, cb) {
+					cb(false, true);
+				},
+				useMfaOtpGrant: function (grantType, req, cb) {
+					req.oauth.client.clientId.should.equal('thom');
+					req.oauth.client.clientSecret.should.equal('nightworld');
+					cb(false, true, { id: 3 });
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				},
+				performMfaOtp: function (req, cb) {
+					cb(new OAuth2Error('rate_limit_exceeded', 'Rate limit exceeded.'));
+				}
+			},
+			grants: ['urn:custom:mfa-otp']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'urn:custom:mfa-otp',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        mfa_token: '123456',
-        otp: '123456'
-      })
-      .expect(429, /Rate limit exceeded./i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'urn:custom:mfa-otp',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				mfa_token: '123456',
+				otp: '123456'
+			})
+			.expect(429, /Rate limit exceeded./i, done);
+	});
 });

--- a/test/grant.password.test.js
+++ b/test/grant.password.test.js
@@ -13,159 +13,165 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (oauthConfig) {
-  var app = express(),
-    oauth = oauth2server(oauthConfig || {
-      model: {},
-      grants: ['password', 'refresh_token']
-    });
+function bootstrap(oauthConfig) {
+	const app = express(),
+		oauth = oauth2server(oauthConfig || {
+			model: {},
+			grants: ['password', 'refresh_token']
+		});
 
-  app.set('json spaces', 0);
-  app.use(bodyParser());
+	app.set('json spaces', 0);
+	app.use(bodyParser());
 
-  app.all('/oauth/token', oauth.grant());
+	app.all('/oauth/token', oauth.grant());
 
-  app.use(oauth.errorHandler());
+	app.use(oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
 describe('Granting with password grant type', function () {
-  it('should detect missing parameters', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        }
-      },
-      grants: ['password']
-    });
+	it('should detect missing parameters', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				}
+			},
+			grants: ['password']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'password',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /missing parameters. \\"username\\" and \\"password\\"/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'password',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /missing parameters. \\"username\\" and \\"password\\"/i, done);
 
-  });
+	});
 
-  it('should detect invalid user', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        checkSSOUser: function (uname) { return Promise.resolve(); },
-        getUser: function (uname, pword, callback) {
-          uname.should.equal('thomseddon');
-          pword.should.equal('nightworld');
-          callback(false, false); // Fake invalid user
-        }
-      },
-      grants: ['password']
-    });
+	it('should detect invalid user', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				checkSSOUser: function (_uname) {
+					return Promise.resolve();
+				},
+				getUser: function (uname, pword, callback) {
+					uname.should.equal('thomseddon');
+					pword.should.equal('nightworld');
+					callback(false, false); // Fake invalid user
+				}
+			},
+			grants: ['password']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'password',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        username: 'thomseddon',
-        password: 'nightworld'
-      })
-      .expect(400, /user credentials are invalid/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'password',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				username: 'thomseddon',
+				password: 'nightworld'
+			})
+			.expect(400, /user credentials are invalid/i, done);
 
-  });
+	});
 
-  it('should detect mfa needed and return an error', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        checkSSOUser: function (uname) { return Promise.resolve(); },
-        getUser: function (uname, pword, callback) {
-          callback(false, { id: 1, mfaEnabled: true });
-        },
-        validateScope: function(scope, client, user, cb) {
-          cb(false, 'foo bar', false);
-        },
-        saveMfaToken: function(user, req, clientId, cb) {
-          cb(false, { mfa_token: '12345678' } );
-        }
-      },
-      grants: ['password']
-    });
+	it('should detect mfa needed and return an error', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				checkSSOUser: function (_uname) {
+					return Promise.resolve();
+				},
+				getUser: function (uname, pword, callback) {
+					callback(false, { id: 1, mfaEnabled: true });
+				},
+				validateScope: function(scope, client, user, cb) {
+					cb(false, 'foo bar', false);
+				},
+				saveMfaToken: function(user, req, clientId, cb) {
+					cb(false, { mfa_token: '12345678' });
+				}
+			},
+			grants: ['password']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'password',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        username: 'thomseddon',
-        password: 'nightworld'
-      })
-      .expect(403, /Multi-factor authentication required/i, done);
-    });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'password',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				username: 'thomseddon',
+				password: 'nightworld'
+			})
+			.expect(403, /Multi-factor authentication required/i, done);
+	});
 
-  it('should pass through mfa if not needed', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        checkSSOUser: function (uname) { return Promise.resolve(); },
-        getUser: function (uname, pword, callback) {
-          callback(false, { id: 1, mfaEnabled: false });
-        },
-        saveAccessToken: function (token, client, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        validateScope: function(scope, client, user, cb) {
-          cb(false, 'foo bar', false);
-        },
-      },
-      grants: ['password']
-    });
+	it('should pass through mfa if not needed', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				checkSSOUser: function (_uname) {
+					return Promise.resolve();
+				},
+				getUser: function (uname, pword, callback) {
+					callback(false, { id: 1, mfaEnabled: false });
+				},
+				saveAccessToken: function (token, client, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				validateScope: function(scope, client, user, cb) {
+					cb(false, 'foo bar', false);
+				},
+			},
+			grants: ['password']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'password',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        username: 'thomseddon',
-        password: 'nightworld'
-      })
-      .expect(200, /"access_token":"(.*)",(.*)"/i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'password',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				username: 'thomseddon',
+				password: 'nightworld'
+			})
+			.expect(200, /"access_token":"(.*)",(.*)"/i, done);
+	});
 });

--- a/test/grant.recovery_code.test.js
+++ b/test/grant.recovery_code.test.js
@@ -1,13 +1,14 @@
-var express = require('express'),
+'use strict';
+
+const express = require('express'),
 	bodyParser = require('body-parser'),
 	request = require('supertest'),
-	should = require('should'),
 	OAuth2Error = require('../lib/error');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (oauthConfig) {
-	var app = express(),
+function bootstrap(oauthConfig) {
+	const app = express(),
 		oauth = oauth2server(oauthConfig || {
 			model: {},
 			grants: ['password', 'refresh_token', 'urn:custom:mfa-otp']
@@ -21,14 +22,14 @@ var bootstrap = function (oauthConfig) {
 	app.use(oauth.errorHandler());
 
 	return app;
-};
+}
 
 describe('Granting with recovery-code grant type', function () {
 	it('should still detect unsupported grant_type', function (done) {
-		var app = bootstrap({
+		const app = bootstrap({
 			model: {
 				getClient: function (id, secret, callback) {
-					callback(false, true);
+					callback(false, {});
 				},
 				grantTypeAllowed: function (clientId, grantType, callback) {
 					callback(false, true);
@@ -52,10 +53,10 @@ describe('Granting with recovery-code grant type', function () {
 	});
 
 	it('should require an mfa_token', function (done) {
-		var app = bootstrap({
+		const app = bootstrap({
 			model: {
 				getClient: function (id, secret, callback) {
-					callback(false, true);
+					callback(false, {});
 				},
 				grantTypeAllowed: function (clientId, grantType, callback) {
 					callback(false, true);
@@ -77,10 +78,10 @@ describe('Granting with recovery-code grant type', function () {
 	});
 
 	it('should require a recovery code', function (done) {
-		var app = bootstrap({
+		const app = bootstrap({
 			model: {
 				getClient: function (id, secret, callback) {
-					callback(false, true);
+					callback(false, {});
 				},
 				grantTypeAllowed: function (clientId, grantType, callback) {
 					callback(false, true);
@@ -102,7 +103,7 @@ describe('Granting with recovery-code grant type', function () {
 	});
 
 	it('should return error from performMfaOtp', function (done) {
-		var app = bootstrap({
+		const app = bootstrap({
 			model: {
 				getClient: function (id, secret, cb) {
 					cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
@@ -142,7 +143,7 @@ describe('Granting with recovery-code grant type', function () {
 	});
 
 	it('should passthrough valid request', function (done) {
-		var app = bootstrap({
+		const app = bootstrap({
 			model: {
 				getClient: function (id, secret, cb) {
 					cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
@@ -181,43 +182,43 @@ describe('Granting with recovery-code grant type', function () {
 			.expect(200, done);
 	});
 
-  it('should return the rate_limit error', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, cb) {
-          cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
-        },
-        grantTypeAllowed: function (clientId, grantType, cb) {
-          cb(false, true);
-        },
-        useMfaOtpGrant: function (grantType, req, cb) {
-          req.oauth.client.clientId.should.equal('thom');
-          req.oauth.client.clientSecret.should.equal('nightworld');
-          cb(false, true, { id: 3 });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        },
-        performRecoveryCode: function (req, cb) {
-          cb(new OAuth2Error('rate_limit_exceeded', 'Rate limit exceeded.'));
-        }
-      },
-      grants: ['urn:custom:recovery-code']
-    });
+	it('should return the rate_limit error', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, cb) {
+					cb(false, { clientId: 'thom', clientSecret: 'nightworld' });
+				},
+				grantTypeAllowed: function (clientId, grantType, cb) {
+					cb(false, true);
+				},
+				useMfaOtpGrant: function (grantType, req, cb) {
+					req.oauth.client.clientId.should.equal('thom');
+					req.oauth.client.clientSecret.should.equal('nightworld');
+					cb(false, true, { id: 3 });
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				},
+				performRecoveryCode: function (req, cb) {
+					cb(new OAuth2Error('rate_limit_exceeded', 'Rate limit exceeded.'));
+				}
+			},
+			grants: ['urn:custom:recovery-code']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'urn:custom:recovery-code',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        mfa_token: '123456',
-        recovery_code: '123456'
-      })
-      .expect(429, /Rate limit exceeded./i, done);
-  });
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'urn:custom:recovery-code',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				mfa_token: '123456',
+				recovery_code: '123456'
+			})
+			.expect(429, /Rate limit exceeded./i, done);
+	});
 });

--- a/test/grant.refresh_token.test.js
+++ b/test/grant.refresh_token.test.js
@@ -13,283 +13,283 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (oauthConfig) {
-  var app = express(),
-    oauth = oauth2server(oauthConfig || {
-      model: {},
-      grants: ['password', 'refresh_token']
-    });
+function bootstrap(oauthConfig) {
+	const app = express(),
+		oauth = oauth2server(oauthConfig || {
+			model: {},
+			grants: ['password', 'refresh_token']
+		});
 
-  app.set('json spaces', 0);
-  app.use(bodyParser());
+	app.set('json spaces', 0);
+	app.use(bodyParser());
 
-  app.all('/oauth/token', oauth.grant());
+	app.all('/oauth/token', oauth.grant());
 
-  app.use(oauth.errorHandler());
+	app.use(oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
 describe('Granting with refresh_token grant type', function () {
-  it('should detect missing refresh_token parameter', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        }
-      },
-      grants: ['password', 'refresh_token']
-    });
+	it('should detect missing refresh_token parameter', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				}
+			},
+			grants: ['password', 'refresh_token']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'refresh_token',
-        client_id: 'thom',
-        client_secret: 'nightworld'
-      })
-      .expect(400, /no \\"refresh_token\\" parameter/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'refresh_token',
+				client_id: 'thom',
+				client_secret: 'nightworld'
+			})
+			.expect(400, /no \\"refresh_token\\" parameter/i, done);
 
-  });
+	});
 
-  it('should detect invalid refresh_token', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getRefreshToken: function (data, callback) {
-          callback(false, false);
-        }
-      },
-      grants: ['password', 'refresh_token']
-    });
+	it('should detect invalid refresh_token', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getRefreshToken: function (data, callback) {
+					callback(false, false);
+				}
+			},
+			grants: ['password', 'refresh_token']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'refresh_token',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        refresh_token: 'abc123'
-      })
-      .expect(400, /invalid refresh token/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'refresh_token',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				refresh_token: 'abc123'
+			})
+			.expect(400, /invalid refresh token/i, done);
 
-  });
+	});
 
-  it('should detect wrong client id', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, true);
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getRefreshToken: function (data, callback) {
-          callback(false, { clientId: 'kate' });
-        }
-      },
-      grants: ['password', 'refresh_token']
-    });
+	it('should detect wrong client id', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, {});
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getRefreshToken: function (data, callback) {
+					callback(false, { clientId: 'kate' });
+				}
+			},
+			grants: ['password', 'refresh_token']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'refresh_token',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        refresh_token: 'abc123'
-      })
-      .expect(400, /invalid refresh token/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'refresh_token',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				refresh_token: 'abc123'
+			})
+			.expect(400, /invalid refresh token/i, done);
 
-  });
+	});
 
-  it('should detect expired refresh token', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: 'thom' });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getRefreshToken: function (data, callback) {
-          callback(false, {
-            clientId: 'thom',
-            expires: new Date(+new Date() - 60)
-          });
-        }
-      },
-      grants: ['password', 'refresh_token']
-    });
+	it('should detect expired refresh token', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: 'thom' });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getRefreshToken: function (data, callback) {
+					callback(false, {
+						clientId: 'thom',
+						expires: new Date(+new Date() - 60)
+					});
+				}
+			},
+			grants: ['password', 'refresh_token']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'refresh_token',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        refresh_token: 'abc123'
-      })
-      .expect(400, /refresh token has expired/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'refresh_token',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				refresh_token: 'abc123'
+			})
+			.expect(400, /refresh token has expired/i, done);
 
-  });
+	});
 
-  it('should allow valid request', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: 'thom' });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getRefreshToken: function (refreshToken, callback) {
-          refreshToken.should.equal('abc123');
-          callback(false, {
-            clientId: 'thom',
-            expires: new Date(),
-            userId: '123'
-          });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
-          cb();
-        },
-        expireRefreshToken: function (refreshToken, callback) {
-          callback();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        }
-      },
-      grants: ['password', 'refresh_token']
-    });
+	it('should allow valid request', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: 'thom' });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getRefreshToken: function (refreshToken, callback) {
+					refreshToken.should.equal('abc123');
+					callback(false, {
+						clientId: 'thom',
+						expires: new Date(),
+						userId: '123'
+					});
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
+					cb();
+				},
+				expireRefreshToken: function (refreshToken, callback) {
+					callback();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				}
+			},
+			grants: ['password', 'refresh_token']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'refresh_token',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        refresh_token: 'abc123'
-      })
-      .expect(200, /"access_token":"(.*)",(.*)"refresh_token":"(.*)"/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'refresh_token',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				refresh_token: 'abc123'
+			})
+			.expect(200, /"access_token":"(.*)",(.*)"refresh_token":"(.*)"/i, done);
 
-  });
+	});
 
-  it('should allow valid request with user object', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: 'thom' });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getRefreshToken: function (refreshToken, callback) {
-          refreshToken.should.equal('abc123');
-          callback(false, {
-            clientId: 'thom',
-            expires: new Date(),
-            user: {
-              id: '123'
-            }
-          });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
-          cb();
-        },
-        expireRefreshToken: function (refreshToken, callback) {
-          callback();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        }
-      },
-      grants: ['password', 'refresh_token']
-    });
+	it('should allow valid request with user object', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: 'thom' });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getRefreshToken: function (refreshToken, callback) {
+					refreshToken.should.equal('abc123');
+					callback(false, {
+						clientId: 'thom',
+						expires: new Date(),
+						user: {
+							id: '123'
+						}
+					});
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
+					cb();
+				},
+				expireRefreshToken: function (refreshToken, callback) {
+					callback();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				}
+			},
+			grants: ['password', 'refresh_token']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'refresh_token',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        refresh_token: 'abc123'
-      })
-      .expect(200, /"access_token":"(.*)",(.*)"refresh_token":"(.*)"/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'refresh_token',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				refresh_token: 'abc123'
+			})
+			.expect(200, /"access_token":"(.*)",(.*)"refresh_token":"(.*)"/i, done);
 
-  });
+	});
 
-  it('should allow valid request with non-expiring token (token= null)', function (done) {
-    var app = bootstrap({
-      model: {
-        getClient: function (id, secret, callback) {
-          callback(false, { clientId: 'thom' });
-        },
-        grantTypeAllowed: function (clientId, grantType, callback) {
-          callback(false, true);
-        },
-        getRefreshToken: function (data, callback) {
-          callback(false, {
-            clientId: 'thom',
-            expires: null,
-            userId: '123'
-          });
-        },
-        saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-          cb();
-        },
-        saveRefreshToken: function (token, clientId, expires, scope, user, cb) {
-          cb();
-        },
-        expireRefreshToken: function (refreshToken, callback) {
-          callback();
-        },
-        validateScope: function (scope, client, user, cb) {
-          cb(false, '', false);
-        }
-      },
-      grants: ['password', 'refresh_token']
-    });
+	it('should allow valid request with non-expiring token (token= null)', function (done) {
+		const app = bootstrap({
+			model: {
+				getClient: function (id, secret, callback) {
+					callback(false, { clientId: 'thom' });
+				},
+				grantTypeAllowed: function (clientId, grantType, callback) {
+					callback(false, true);
+				},
+				getRefreshToken: function (data, callback) {
+					callback(false, {
+						clientId: 'thom',
+						expires: null,
+						userId: '123'
+					});
+				},
+				saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+					cb();
+				},
+				saveRefreshToken: function (token, clientId, expires, scope, user, cb) {
+					cb();
+				},
+				expireRefreshToken: function (refreshToken, callback) {
+					callback();
+				},
+				validateScope: function (scope, client, user, cb) {
+					cb(false, '', false);
+				}
+			},
+			grants: ['password', 'refresh_token']
+		});
 
-    request(app)
-      .post('/oauth/token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({
-        grant_type: 'refresh_token',
-        client_id: 'thom',
-        client_secret: 'nightworld',
-        refresh_token: 'abc123'
-      })
-      .expect(200, /"access_token":"(.*)",(.*)"refresh_token":"(.*)"/i, done);
+		request(app)
+			.post('/oauth/token')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				grant_type: 'refresh_token',
+				client_id: 'thom',
+				client_secret: 'nightworld',
+				refresh_token: 'abc123'
+			})
+			.expect(200, /"access_token":"(.*)",(.*)"refresh_token":"(.*)"/i, done);
 
-  });
+	});
 });

--- a/test/grant.test.js
+++ b/test/grant.test.js
@@ -481,7 +481,7 @@ describe('Grant', function() {
 						return done(err);
 					}
 
-					res.body.should.have.keys(['access_token', 'token_type', 'expires_in']);
+					res.body.should.have.keys('access_token', 'token_type', 'expires_in');
 					res.body.access_token.should.be.instanceOf(String);
 					res.body.access_token.should.have.length(40);
 					res.body.token_type.should.equal('bearer');
@@ -532,8 +532,7 @@ describe('Grant', function() {
 						return done(err);
 					}
 
-					res.body.should.have.keys(['access_token', 'token_type', 'expires_in',
-						'refresh_token']);
+					res.body.should.have.keys('access_token', 'token_type', 'expires_in', 'refresh_token');
 					res.body.access_token.should.be.instanceOf(String);
 					res.body.access_token.should.have.length(40);
 					res.body.refresh_token.should.be.instanceOf(String);
@@ -584,8 +583,7 @@ describe('Grant', function() {
 						return done(err);
 					}
 
-					res.body.should.have.keys(['access_token', 'token_type', 'expires_in',
-						'refresh_token', 'scope']);
+					res.body.should.have.keys('access_token', 'token_type', 'expires_in', 'refresh_token', 'scope');
 					res.body.access_token.should.be.instanceOf(String);
 					res.body.access_token.should.have.length(40);
 					res.body.expires_in.should.equal(3600);
@@ -640,7 +638,7 @@ describe('Grant', function() {
 						return done(err);
 					}
 
-					res.body.should.have.keys(['access_token', 'token_type']);
+					res.body.should.have.keys('access_token', 'token_type');
 					res.body.access_token.should.be.instanceOf(String);
 					res.body.access_token.should.have.length(40);
 					res.body.token_type.should.equal('bearer');

--- a/test/grant.test.js
+++ b/test/grant.test.js
@@ -13,730 +13,765 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest'),
+	should = require('should');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (oauthConfig) {
-  var app = express(),
-    oauth = oauth2server(oauthConfig || {
-      model: {},
-      grants: ['password', 'refresh_token']
-    });
+function bootstrap(oauthConfig) {
+	const app = express(),
+		oauth = oauth2server(oauthConfig || {
+			model: {},
+			grants: ['password', 'refresh_token']
+		});
 
-  app.set('json spaces', 0);
-  app.use(bodyParser());
+	app.set('json spaces', 0);
+	app.use(bodyParser());
 
-  app.all('/oauth/token', oauth.grant());
+	app.all('/oauth/token', oauth.grant());
 
-  app.use(oauth.errorHandler());
+	app.use(oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
-var validBody = {
-  grant_type: 'password',
-  client_id: 'thom',
-  client_secret: 'nightworld',
-  username: 'thomseddon',
-  password: 'nightworld',
-  scope: 'foobar'
+const validBody = {
+	grant_type: 'password',
+	client_id: 'thom',
+	client_secret: 'nightworld',
+	username: 'thomseddon',
+	password: 'nightworld',
+	scope: 'foobar'
 };
 
 describe('Grant', function() {
 
-  describe('when parsing request', function () {
-    it('should only allow post', function (done) {
-      var app = bootstrap();
-
-      request(app)
-        .get('/oauth/token')
-        .expect(400, /method must be POST/i, done);
-    });
-
-    it('should only allow application/x-www-form-urlencoded', function (done) {
-      var app = bootstrap();
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/json')
-        .send({}) // Required to be valid JSON
-        .expect(400, /application\/x-www-form-urlencoded/i, done);
-    });
-
-    it('should check grant_type exists', function (done) {
-      var app = bootstrap();
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .expect(400, /invalid or missing grant_type parameter/i, done);
-    });
-
-    it('should ensure grant_type is allowed', function (done) {
-      var app = bootstrap({ model: {}, grants: ['refresh_token'] });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password' })
-        .expect(400, /invalid or missing grant_type parameter/i, done);
-    });
-
-    it('should check client_id exists', function (done) {
-      var app = bootstrap();
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password' })
-        .expect(400, /invalid or missing client_id parameter/i, done);
-    });
-
-    it('should check client_id matches regex', function (done) {
-      var app = bootstrap({
-        clientIdRegex: /match/,
-        model: {},
-        grants: ['password', 'refresh_token']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom' })
-        .expect(400, /invalid or missing client_id parameter/i, done);
-    });
-
-    it('should check client_secret exists', function (done) {
-      var app = bootstrap();
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom' })
-        .expect(400, /missing client_secret parameter/i, done);
-    });
-
-    it('should extract credentials from body', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            id.should.equal('thom');
-            secret.should.equal('nightworld');
-            callback(false, false);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect(400, done);
-    });
-
-    it('should extract credentials from header (Basic)', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            id.should.equal('thom');
-            secret.should.equal('nightworld');
-            callback(false, false);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .send('grant_type=password&username=test&password=invalid')
-        .set('Authorization', 'Basic dGhvbTpuaWdodHdvcmxk')
-        .expect(400, done);
-    });
-
-    it('should detect unsupported grant_type', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, true);
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          }
-        },
-        grants: ['refresh_token']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect(400, /invalid or missing grant_type/i, done);
-    });
-  });
-
-  describe('check client credentials against model', function () {
-    it('should detect invalid client', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, false); // Fake invalid
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect(400, /client credentials are invalid/i, done);
-    });
-
-    it('should detect SSO user', function (done) {
-
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, true);
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function fakeSSO (uname) {
-            return Promise.reject('User is SSO'); // Fake SSO validation
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(403, /User is SSO/i, done);
-    });
-  });
-
-  describe('check grant type allowed for client (via model)', function () {
-    it('should detect grant type not allowed', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, true);
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, false); // Not allowed
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect(400, /grant type is unauthorised for this client_id/i, done);
-    });
-  });
-
-  describe('generate access token', function () {
-    it('should allow override via model', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, true);
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          generateToken: function (type, req, callback) {
-            callback(false, 'thommy');
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            token.should.equal('thommy');
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, '', false);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200, /thommy/, done);
-
-    });
-
-    it('should include client and user in request', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { clientId: 'thom', clientSecret: 'nightworld' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          generateToken: function (type, req, callback) {
-            req.oauth.client.clientId.should.equal('thom');
-            req.oauth.client.clientSecret.should.equal('nightworld');
-            req.user.id.should.equal(1);
-            callback(false, 'thommy');
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            token.should.equal('thommy');
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, '', false);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200, /thommy/, done);
-
-    });
-
-    it('should reissue if model returns object', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, true);
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          generateToken: function (type, req, callback) {
-            callback(false, { accessToken: 'thommy' });
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            cb(new Error('Should not be saving'));
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, '', false);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200, /"access_token":"thommy"/, done);
-
-    });
-  });
-
-  describe('saving access token', function () {
-    it('should pass valid params to model.saveAccessToken', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { clientId: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, client, expires, user, scope, grantType, cb) {
-            token.should.be.instanceOf(String);
-            token.should.have.length(40);
-            client.clientId.should.equal('thom');
-            user.id.should.equal(1);
-            scope.should.equal('foobar');
-            (+expires).should.be.within(10, (+new Date()) + 3600000);
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, 'foobar', false);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200, done);
-
-    });
-
-    it('should pass valid params to model.saveRefreshToken', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { clientId: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            cb();
-          },
-          saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
-            token.should.be.instanceOf(String);
-            token.should.have.length(40);
-            clientId.should.equal('thom');
-            user.id.should.equal(1);
-            (+expires).should.be.within(10, (+new Date()) + 3600000 + 1209600000);
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, '', false);
-          }
-        },
-        grants: ['password', 'refresh_token']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200, done);
-
-    });
-  });
-
-  describe('issue access token', function () {
-    it('should return an oauth compatible response', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { clientId: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, '', false);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200)
-        .expect('Cache-Control', 'no-store')
-        .expect('Pragma', 'no-cache')
-        .end(function (err, res) {
-          if (err) return done(err);
-
-          res.body.should.have.keys(['access_token', 'token_type', 'expires_in']);
-          res.body.access_token.should.be.instanceOf(String);
-          res.body.access_token.should.have.length(40);
-          res.body.token_type.should.equal('bearer');
-          res.body.expires_in.should.equal(3600);
-
-          done();
-        });
-
-    });
-
-    it('should return an oauth compatible response with refresh_token', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { client_id: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            cb();
-          },
-          saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, '', false);
-          }
-        },
-        grants: ['password', 'refresh_token']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200)
-        .expect('Cache-Control', 'no-store')
-        .expect('Pragma', 'no-cache')
-        .end(function (err, res) {
-          if (err) return done(err);
-
-          res.body.should.have.keys(['access_token', 'token_type', 'expires_in',
-            'refresh_token']);
-          res.body.access_token.should.be.instanceOf(String);
-          res.body.access_token.should.have.length(40);
-          res.body.refresh_token.should.be.instanceOf(String);
-          res.body.refresh_token.should.have.length(40);
-          res.body.token_type.should.equal('bearer');
-          res.body.expires_in.should.equal(3600);
-
-          done();
-        });
-
-    });
-
-    it('should return an oauth compatible response with scope', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { client_id: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            cb();
-          },
-          saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, 'foobar', false);
-          }
-        },
-        grants: ['password', 'refresh_token']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld', username: 'thomseddon', password: 'nightworld', scope: 'foobar' })
-        .expect(200)
-        .end(function (err, res) {
-          if (err) return done(err);
-
-          res.body.should.have.keys(['access_token', 'token_type', 'expires_in',
-            'refresh_token', 'scope']);
-          res.body.access_token.should.be.instanceOf(String);
-          res.body.access_token.should.have.length(40);
-          res.body.expires_in.should.equal(3600);
-          res.body.refresh_token.should.be.instanceOf(String);
-          res.body.refresh_token.should.have.length(40);
-          res.body.scope.should.equal('foobar');
-          res.body.token_type.should.equal('bearer');
-
-          done();
-        });
-    });
-
-    it('should exclude expires_in if accessTokenLifetime = null', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { clientId: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            should.strictEqual(null, expires);
-            cb();
-          },
-          saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
-            should.strictEqual(null, expires);
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, '', false);
-          }
-        },
-        grants: ['password', 'refresh_token'],
-        accessTokenLifetime: null,
-        refreshTokenLifetime: null
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200)
-        .end(function (err, res) {
-          if (err) return done(err);
-
-          res.body.should.have.keys(['access_token', 'token_type']);
-          res.body.access_token.should.be.instanceOf(String);
-          res.body.access_token.should.have.length(40);
-          res.body.token_type.should.equal('bearer');
-
-          done();
-        });
-
-    });
-
-    it('should continue after success response if continueAfterResponse = true', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { clientId: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            cb();
-          },
-          validateScope: function (scope, client, user, cb) {
-            cb(null, '', false);
-          }
-        },
-        grants: ['password'],
-        continueAfterResponse: true
-      });
-
-      var hit = false;
-      app.all('*', function (req, res, done) {
-        hit = true;
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send(validBody)
-        .expect(200)
-        .end(function (err, res) {
-          if (err) return done(err);
-          hit.should.equal(true);
-          done();
-        });
-    });
-
-  });
-
-  describe('saving scope', function () {
-    it('should not allow invalid scopes', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { client_id: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
-            token.should.be.instanceOf(String);
-            token.should.have.length(40);
-            clientId.should.equal('thom');
-            user.id.should.equal(1);
-            (+expires).should.be.within(10, (+new Date()) + 3600000);
-            cb();
-          },
-          validateScope: function(scope, client, user, cb) {
-            cb(false, false, true);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld', username: 'thomseddon', password: 'nightworld', scope: 'foo bar' })
-        .expect(400, /invalid_scope/, done);
-
-    });
-
-    it('should allow valid scopes', function (done) {
-      var app = bootstrap({
-        model: {
-          getClient: function (id, secret, callback) {
-            callback(false, { clientId: 'thom' });
-          },
-          grantTypeAllowed: function (clientId, grantType, callback) {
-            callback(false, true);
-          },
-          checkSSOUser: function (uname) { return Promise.resolve(); },
-          getUser: function (uname, pword, callback) {
-            callback(false, { id: 1 });
-          },
-          saveAccessToken: function (token, client, expires, user, scope, grantType, cb) {
-            token.should.be.instanceOf(String);
-            token.should.have.length(40);
-            client.clientId.should.equal('thom');
-            user.id.should.equal(1);
-            (+expires).should.be.within(10, (+new Date()) + 3600000);
-            cb();
-          },
-          validateScope: function(scope, client, user, cb) {
-            cb(false, 'foo bar', false);
-          }
-        },
-        grants: ['password']
-      });
-
-      request(app)
-        .post('/oauth/token')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld', username: 'thomseddon', password: 'nightworld', scope: 'foo bar' })
-        .expect(200, /foo bar/, done);
-    });
-  });
+	describe('when parsing request', function () {
+		it('should only allow post', function (done) {
+			const app = bootstrap();
+
+			request(app)
+				.get('/oauth/token')
+				.expect(400, /method must be POST/i, done);
+		});
+
+		it('should only allow application/x-www-form-urlencoded', function (done) {
+			const app = bootstrap();
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/json')
+				.send({}) // Required to be valid JSON
+				.expect(400, /application\/x-www-form-urlencoded/i, done);
+		});
+
+		it('should check grant_type exists', function (done) {
+			const app = bootstrap();
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.expect(400, /invalid or missing grant_type parameter/i, done);
+		});
+
+		it('should ensure grant_type is allowed', function (done) {
+			const app = bootstrap({ model: {}, grants: ['refresh_token'] });
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password' })
+				.expect(400, /invalid or missing grant_type parameter/i, done);
+		});
+
+		it('should check client_id exists', function (done) {
+			const app = bootstrap();
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password' })
+				.expect(400, /invalid or missing client_id parameter/i, done);
+		});
+
+		it('should check client_id matches regex', function (done) {
+			const app = bootstrap({
+				clientIdRegex: /match/,
+				model: {},
+				grants: ['password', 'refresh_token']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom' })
+				.expect(400, /invalid or missing client_id parameter/i, done);
+		});
+
+		it('should check client_secret exists', function (done) {
+			const app = bootstrap();
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom' })
+				.expect(400, /missing client_secret parameter/i, done);
+		});
+
+		it('should extract credentials from body', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						id.should.equal('thom');
+						secret.should.equal('nightworld');
+						callback(false, false);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
+				.expect(400, done);
+		});
+
+		it('should extract credentials from header (Basic)', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						id.should.equal('thom');
+						secret.should.equal('nightworld');
+						callback(false, false);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.send('grant_type=password&username=test&password=invalid')
+				.set('Authorization', 'Basic dGhvbTpuaWdodHdvcmxk')
+				.expect(400, done);
+		});
+
+		it('should detect unsupported grant_type', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, true);
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					}
+				},
+				grants: ['refresh_token']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
+				.expect(400, /invalid or missing grant_type/i, done);
+		});
+	});
+
+	describe('check client credentials against model', function () {
+		it('should detect invalid client', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, null); // Fake invalid
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
+				.expect(400, /client credentials are invalid/i, done);
+		});
+
+		it('should detect SSO user', function (done) {
+
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, {});
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function fakeSSO (_uname) {
+						return Promise.reject('User is SSO'); // Fake SSO validation
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(403, /User is SSO/i, done);
+		});
+	});
+
+	describe('check grant type allowed for client (via model)', function () {
+		it('should detect grant type not allowed', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, {});
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, false); // Not allowed
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
+				.expect(400, /grant type is unauthorised for this client_id/i, done);
+		});
+	});
+
+	describe('generate access token', function () {
+		it('should allow override via model', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, {});
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					generateToken: function (type, req, callback) {
+						callback(false, 'thommy');
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						token.should.equal('thommy');
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, '', false);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200, /thommy/, done);
+
+		});
+
+		it('should include client and user in request', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { clientId: 'thom', clientSecret: 'nightworld' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					generateToken: function (type, req, callback) {
+						req.oauth.client.clientId.should.equal('thom');
+						req.oauth.client.clientSecret.should.equal('nightworld');
+						req.user.id.should.equal(1);
+						callback(false, 'thommy');
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						token.should.equal('thommy');
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, '', false);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200, /thommy/, done);
+
+		});
+
+		it('should reissue if model returns object', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, {});
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					generateToken: function (type, req, callback) {
+						callback(false, { accessToken: 'thommy' });
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						cb(new Error('Should not be saving'));
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, '', false);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200, /"access_token":"thommy"/, done);
+
+		});
+	});
+
+	describe('saving access token', function () {
+		it('should pass valid params to model.saveAccessToken', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { clientId: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, client, expires, user, scope, grantType, cb) {
+						token.should.be.instanceOf(String);
+						token.should.have.length(40);
+						client.clientId.should.equal('thom');
+						user.id.should.equal(1);
+						scope.should.equal('foobar');
+						(+expires).should.be.within(10, (+new Date()) + 3600000);
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, 'foobar', false);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200, done);
+
+		});
+
+		it('should pass valid params to model.saveRefreshToken', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { clientId: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						cb();
+					},
+					saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
+						token.should.be.instanceOf(String);
+						token.should.have.length(40);
+						clientId.should.equal('thom');
+						user.id.should.equal(1);
+						(+expires).should.be.within(10, (+new Date()) + 3600000 + 1209600000);
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, '', false);
+					}
+				},
+				grants: ['password', 'refresh_token']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200, done);
+
+		});
+	});
+
+	describe('issue access token', function () {
+		it('should return an oauth compatible response', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { clientId: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, '', false);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200)
+				.expect('Cache-Control', 'no-store')
+				.expect('Pragma', 'no-cache')
+				.end(function (err, res) {
+					if (err) {
+						return done(err);
+					}
+
+					res.body.should.have.keys(['access_token', 'token_type', 'expires_in']);
+					res.body.access_token.should.be.instanceOf(String);
+					res.body.access_token.should.have.length(40);
+					res.body.token_type.should.equal('bearer');
+					res.body.expires_in.should.equal(3600);
+
+					done();
+				});
+
+		});
+
+		it('should return an oauth compatible response with refresh_token', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { client_id: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						cb();
+					},
+					saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, '', false);
+					}
+				},
+				grants: ['password', 'refresh_token']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200)
+				.expect('Cache-Control', 'no-store')
+				.expect('Pragma', 'no-cache')
+				.end(function (err, res) {
+					if (err) {
+						return done(err);
+					}
+
+					res.body.should.have.keys(['access_token', 'token_type', 'expires_in',
+						'refresh_token']);
+					res.body.access_token.should.be.instanceOf(String);
+					res.body.access_token.should.have.length(40);
+					res.body.refresh_token.should.be.instanceOf(String);
+					res.body.refresh_token.should.have.length(40);
+					res.body.token_type.should.equal('bearer');
+					res.body.expires_in.should.equal(3600);
+
+					done();
+				});
+
+		});
+
+		it('should return an oauth compatible response with scope', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { client_id: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						cb();
+					},
+					saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, 'foobar', false);
+					}
+				},
+				grants: ['password', 'refresh_token']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld', username: 'thomseddon', password: 'nightworld', scope: 'foobar' })
+				.expect(200)
+				.end(function (err, res) {
+					if (err) {
+						return done(err);
+					}
+
+					res.body.should.have.keys(['access_token', 'token_type', 'expires_in',
+						'refresh_token', 'scope']);
+					res.body.access_token.should.be.instanceOf(String);
+					res.body.access_token.should.have.length(40);
+					res.body.expires_in.should.equal(3600);
+					res.body.refresh_token.should.be.instanceOf(String);
+					res.body.refresh_token.should.have.length(40);
+					res.body.scope.should.equal('foobar');
+					res.body.token_type.should.equal('bearer');
+
+					done();
+				});
+		});
+
+		it('should exclude expires_in if accessTokenLifetime = null', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { clientId: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						should.strictEqual(null, expires);
+						cb();
+					},
+					saveRefreshToken: function (token, clientId, expires, user, scope, cb) {
+						should.strictEqual(null, expires);
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, '', false);
+					}
+				},
+				grants: ['password', 'refresh_token'],
+				accessTokenLifetime: null,
+				refreshTokenLifetime: null
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200)
+				.end(function (err, res) {
+					if (err) {
+						return done(err);
+					}
+
+					res.body.should.have.keys(['access_token', 'token_type']);
+					res.body.access_token.should.be.instanceOf(String);
+					res.body.access_token.should.have.length(40);
+					res.body.token_type.should.equal('bearer');
+
+					done();
+				});
+
+		});
+
+		it('should continue after success response if continueAfterResponse = true', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { clientId: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						cb();
+					},
+					validateScope: function (scope, client, user, cb) {
+						cb(null, '', false);
+					}
+				},
+				grants: ['password'],
+				continueAfterResponse: true
+			});
+
+			let hit = false;
+			app.all('*', function (_req, _res, _next) {
+				hit = true;
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send(validBody)
+				.expect(200)
+				.end(function (err, _res) {
+					if (err) {
+						return done(err);
+					}
+					hit.should.equal(true);
+					done();
+				});
+		});
+
+	});
+
+	describe('saving scope', function () {
+		it('should not allow invalid scopes', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { client_id: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, clientId, expires, user, scope, grantType, cb) {
+						token.should.be.instanceOf(String);
+						token.should.have.length(40);
+						clientId.should.equal('thom');
+						user.id.should.equal(1);
+						(+expires).should.be.within(10, (+new Date()) + 3600000);
+						cb();
+					},
+					validateScope: function(scope, client, user, cb) {
+						cb(false, false, true);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld', username: 'thomseddon', password: 'nightworld', scope: 'foo bar' })
+				.expect(400, /invalid_scope/, done);
+
+		});
+
+		it('should allow valid scopes', function (done) {
+			const app = bootstrap({
+				model: {
+					getClient: function (id, secret, callback) {
+						callback(false, { clientId: 'thom' });
+					},
+					grantTypeAllowed: function (clientId, grantType, callback) {
+						callback(false, true);
+					},
+					checkSSOUser: function (_uname) {
+						return Promise.resolve();
+					},
+					getUser: function (uname, pword, callback) {
+						callback(false, { id: 1 });
+					},
+					saveAccessToken: function (token, client, expires, user, scope, grantType, cb) {
+						token.should.be.instanceOf(String);
+						token.should.have.length(40);
+						client.clientId.should.equal('thom');
+						user.id.should.equal(1);
+						(+expires).should.be.within(10, (+new Date()) + 3600000);
+						cb();
+					},
+					validateScope: function(scope, client, user, cb) {
+						cb(false, 'foo bar', false);
+					}
+				},
+				grants: ['password']
+			});
+
+			request(app)
+				.post('/oauth/token')
+				.set('Content-Type', 'application/x-www-form-urlencoded')
+				.send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld', username: 'thomseddon', password: 'nightworld', scope: 'foo bar' })
+				.expect(200, /foo bar/, done);
+		});
+	});
 
 });

--- a/test/implicit.test.js
+++ b/test/implicit.test.js
@@ -1,124 +1,126 @@
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+'use strict';
 
-var oauth2server = require('../');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest'),
+	should = require('should');
 
-var bootstrap = function (model, params, continueAfterResponse) {
+const oauth2server = require('../');
 
-  var app = express();
-  app.oauth = oauth2server({
-    model: model || {},
-    continueAfterResponse: continueAfterResponse
-  });
+function bootstrap(model, params, continueAfterResponse) {
 
-  app.use(bodyParser());
+	const app = express();
+	app.oauth = oauth2server({
+		model: model || {},
+		continueAfterResponse: continueAfterResponse
+	});
 
-  app.post('/authorise', app.oauth.implicit(function (req, client, next) {
-    next.apply(null, params || []);
-  }));
+	app.use(bodyParser());
 
-  app.get('/authorise', app.oauth.implicit(function (req, client, next) {
-    next.apply(null, params || []);
-  }));
+	app.post('/authorise', app.oauth.implicit(function (req, client, next) {
+		next.apply(null, params || []);
+	}));
 
-  app.use(app.oauth.errorHandler());
+	app.get('/authorise', app.oauth.implicit(function (req, client, next) {
+		next.apply(null, params || []);
+	}));
 
-  return app;
-};
+	app.use(app.oauth.errorHandler());
+
+	return app;
+}
 
 describe('ImplicitGrant', function() {
-  it('should try to save access token', function (done) {
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAccessToken: function (accessToken, client, expires, user, scope, grantType, callback) {
-        should.exist(accessToken);
-        accessToken.should.have.lengthOf(40);
-        client.clientId.should.equal('thom');
-        (+expires).should.be.within(2, (+new Date()) + 3600000);
-        done();
-      }
-    }, [false, true]);
+	it('should try to save access token', function (done) {
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAccessToken: function (accessToken, client, expires, _user, _scope, _grantType, _callback) {
+				should.exist(accessToken);
+				accessToken.should.have.lengthOf(40);
+				client.clientId.should.equal('thom');
+				(+expires).should.be.within(2, (+new Date()) + 3600000);
+				done();
+			}
+		}, [false, true]);
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'token',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .end();
-  });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'token',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.end();
+	});
 
-  it('should accept valid request and return token using POST', function (done) {
-    var token;
+	it('should accept valid request and return token using POST', function (done) {
+		let token;
 
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAccessToken: function (accessToken, client, expires, user, scope, grantType, callback) {
-        should.exist(accessToken);
-        token = accessToken;
-        callback();
-      }
-    }, [false, true]);
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAccessToken: function (accessToken, client, expires, user, scope, grantType, callback) {
+				should.exist(accessToken);
+				token = accessToken;
+				callback();
+			}
+		}, [false, true]);
 
-    request(app)
-      .post('/authorise')
-      .send({
-        response_type: 'token',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .expect(302, function (err, res) {
-        if (err) {
-          return done(err);
-        }
-        res.header.location.should.equal('http://nightworld.com#token=' + token);
-        done();
-      });
-  });
+		request(app)
+			.post('/authorise')
+			.send({
+				response_type: 'token',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.expect(302, function (err, res) {
+				if (err) {
+					return done(err);
+				}
+				res.header.location.should.equal('http://nightworld.com#token=' + token);
+				done();
+			});
+	});
 
-  it('should accept valid request and return token using GET', function (done) {
-    var token;
+	it('should accept valid request and return token using GET', function (done) {
+		let token;
 
-    var app = bootstrap({
-      getClient: function (clientId, clientSecret, callback) {
-        callback(false, {
-          clientId: 'thom',
-          redirectUri: 'http://nightworld.com'
-        });
-      },
-      saveAccessToken: function (accessToken, client, expires, user, scope, grantType, callback) {
-        should.exist(accessToken);
-        token = accessToken;
-        callback();
-      }
-    }, [false, true]);
+		const app = bootstrap({
+			getClient: function (clientId, clientSecret, callback) {
+				callback(false, {
+					clientId: 'thom',
+					redirectUri: 'http://nightworld.com'
+				});
+			},
+			saveAccessToken: function (accessToken, client, expires, user, scope, grantType, callback) {
+				should.exist(accessToken);
+				token = accessToken;
+				callback();
+			}
+		}, [false, true]);
 
-    request(app)
-      .get('/authorise')
-      .query({
-        response_type: 'token',
-        client_id: 'thom',
-        redirect_uri: 'http://nightworld.com'
-      })
-      .expect(302, function (err, res) {
-        if (err) {
-          return done(err);
-        }
-        res.header.location.should.equal('http://nightworld.com#token=' + token);
-        done();
-      });
-  });
+		request(app)
+			.get('/authorise')
+			.query({
+				response_type: 'token',
+				client_id: 'thom',
+				redirect_uri: 'http://nightworld.com'
+			})
+			.expect(302, function (err, res) {
+				if (err) {
+					return done(err);
+				}
+				res.header.location.should.equal('http://nightworld.com#token=' + token);
+				done();
+			});
+	});
 });

--- a/test/lockdown.test.js
+++ b/test/lockdown.test.js
@@ -13,124 +13,126 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
-var Authorise = require('../lib/authorise');
+const oauth2server = require('../');
+const Authorise = require('../lib/authorise');
 
-var bootstrap = function (oauthConfig) {
-  var app = express();
-  app.oauth = oauth2server(oauthConfig || {
-      model: {}
-    });
+function bootstrap(oauthConfig) {
+	const app = express();
+	app.oauth = oauth2server(oauthConfig || {
+		model: {}
+	});
 
-  app.use(bodyParser());
+	app.use(bodyParser());
 
-  app.all('/oauth/token', app.oauth.grant);
+	app.all('/oauth/token', app.oauth.grant);
 
-  app.all('/private', function (req, res, next) {
-    res.send('Hello');
-  });
+	app.all('/private', function (req, res, _next) {
+		res.send('Hello');
+	});
 
-  app.all('/public', app.oauth.bypass, function (req, res, next) {
-    res.send('Hello');
-  });
+	app.all('/public', app.oauth.bypass, function (req, res, _next) {
+		res.send('Hello');
+	});
 
 
-  app.oauth.lockdown(app);
+	app.oauth.lockdown(app);
 
-  app.use(app.oauth.errorHandler());
+	app.use(app.oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
 describe('Lockdown pattern', function() {
 
-  it('should substitute grant', function (done) {
-    var app = bootstrap();
+	it('should substitute grant', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .get('/oauth/token')
-      .expect(400, /method must be POST/i, done);
-  });
+		request(app)
+			.get('/oauth/token')
+			.expect(400, /method must be POST/i, done);
+	});
 
-  it('should insert authorise by default', function (done) {
-    var app = bootstrap();
+	it('should insert authorise by default', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .get('/private')
-      .expect(400, /access token was not found/i, done);
-  });
+		request(app)
+			.get('/private')
+			.expect(400, /access token was not found/i, done);
+	});
 
-  it('should pass valid request through authorise', function (done) {
-    var app = bootstrap({
-      model: {
-        getAccessToken: function (token, callback) {
-          callback(token !== 'thom', { access_token: token, expires: null });
-        }
-      }
-    });
+	it('should pass valid request through authorise', function (done) {
+		const app = bootstrap({
+			model: {
+				getAccessToken: function (token, callback) {
+					callback(token !== 'thom', { access_token: token, expires: null });
+				}
+			}
+		});
 
-    request(app)
-      .get('/private?access_token=thom')
-      .expect(200, /hello/i, done);
-  });
+		request(app)
+			.get('/private?access_token=thom')
+			.expect(200, /hello/i, done);
+	});
 
-  it('should correctly bypass', function (done) {
-    var app = bootstrap();
+	it('should correctly bypass', function (done) {
+		const app = bootstrap();
 
-    request(app)
-      .get('/public')
-      .expect(200, /hello/i, done);
-  });
+		request(app)
+			.get('/public')
+			.expect(200, /hello/i, done);
+	});
 
-  describe('in express 3', function () {
-    var app, privateAction, publicAction;
+	describe('in express 3', function () {
+		let app, privateAction, publicAction;
 
-    beforeEach(function () {
-      privateAction = function () {};
-      publicAction = function () {};
+		beforeEach(function () {
+			privateAction = function () {};
+			publicAction = function () {};
 
-      // mock express 3 app
-      app = {
-        routes: { get: [] }
-      };
+			// mock express 3 app
+			app = {
+				routes: { get: [] }
+			};
 
-      app.oauth = oauth2server({ model: {} });
-      app.routes.get.push({ callbacks: [ privateAction ] });
-      app.routes.get.push({ callbacks: [ app.oauth.bypass, publicAction ] });
-      app.oauth.lockdown(app);
-    });
+			app.oauth = oauth2server({ model: {} });
+			app.routes.get.push({ callbacks: [privateAction] });
+			app.routes.get.push({ callbacks: [app.oauth.bypass, publicAction] });
+			app.oauth.lockdown(app);
+		});
 
-    function mockRequest(authoriseFactory) {
-      var req = {
-        get: function () {},
-        query: { access_token: { expires: null } },
-        headers: {},
-        body: {}
-      };
-      var next = function () {};
+		function mockRequest(authoriseFactory) {
+			const req = {
+				get: function () {},
+				query: { access_token: { expires: null } },
+				headers: {},
+				body: {}
+			};
+			const next = () => {};
 
-      app.oauth.model.getAccessToken = function (t, c) { c(null, t); };
+			app.oauth.model.getAccessToken = function (t, c) {
+				c(null, t);
+			};
 
-      return authoriseFactory(req, null, next);
-    }
+			return authoriseFactory(req, null, next);
+		}
 
-    it('adds authorise to non-bypassed routes', function () {
-      var authorise = mockRequest(app.routes.get[0].callbacks[0]);
-      authorise.should.be.an.instanceOf(Authorise);
-    });
+		it('adds authorise to non-bypassed routes', function () {
+			const authorise = mockRequest(app.routes.get[0].callbacks[0]);
+			authorise.should.be.an.instanceOf(Authorise);
+		});
 
-    it('runs non-bypassed routes after authorise', function () {
-      app.routes.get[0].callbacks[1].should.equal(privateAction);
-    });
+		it('runs non-bypassed routes after authorise', function () {
+			app.routes.get[0].callbacks[1].should.equal(privateAction);
+		});
 
-    it('removes oauth.bypass from bypassed routes', function () {
-      app.routes.get[1].callbacks[0].should.equal(publicAction);
-    });
-  });
+		it('removes oauth.bypass from bypassed routes', function () {
+			app.routes.get[1].callbacks[0].should.equal(publicAction);
+		});
+	});
 });

--- a/test/scope.test.js
+++ b/test/scope.test.js
@@ -13,71 +13,71 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-var express = require('express'),
-  bodyParser = require('body-parser'),
-  request = require('supertest'),
-  should = require('should');
+const express = require('express'),
+	bodyParser = require('body-parser'),
+	request = require('supertest');
 
-var oauth2server = require('../');
+const oauth2server = require('../');
 
-var bootstrap = function (scope) {
-  var app = express();
+function bootstrap(scope) {
+	const app = express();
 
-  app.oauth = oauth2server({
-    model: {
-      getAccessToken: function (token, callback) {
-        var expires = new Date(Date.now() * 2);
+	app.oauth = oauth2server({
+		model: {
+			getAccessToken: function (token, callback) {
+				const expires = new Date(Date.now() * 2);
 
-        callback(false, { expires: expires });
-      },
-      authoriseScope: function (accessToken, scope, cb) {
-        cb(false, 'my-scope' !== scope);
-      }
-    }
-  });
+				callback(false, { expires: expires });
+			},
+			authoriseScope: function (accessToken, scope, cb) {
+				cb(false, 'my-scope' !== scope);
+			}
+		}
+	});
 
-  app.use(bodyParser());
+	app.use(bodyParser());
 
-  app.get('/', app.oauth.authorise({ scope: scope }), app.oauth.scope(scope), function (req, res) {
-    res.send('nightworld');
-  });
+	app.get('/', app.oauth.authorise({ scope: scope }), app.oauth.scope(scope), function (req, res) {
+		res.send('nightworld');
+	});
 
-  app.use(app.oauth.errorHandler());
+	app.use(app.oauth.errorHandler());
 
-  return app;
-};
+	return app;
+}
 
 describe('Scope', function () {
 
-  it('should not allow if not authorized', function (done) {
-    var app = bootstrap('foobar');
+	it('should not allow if not authorized', function (done) {
+		const app = bootstrap('foobar');
 
-    app.get('/unauthorised', app.oauth.scope('foobar'), function (req, res) {
-      res.send('nightworld');
-    });
+		app.get('/unauthorised', app.oauth.scope('foobar'), function (req, res) {
+			res.send('nightworld');
+		});
 
-    app.use(app.oauth.errorHandler());
+		app.use(app.oauth.errorHandler());
 
-    request(app)
-      .get('/unauthorised')
-      .expect(400, /invalid_request/, done);
-  });
+		request(app)
+			.get('/unauthorised')
+			.expect(400, /invalid_request/, done);
+	});
 
-  it('should not allow if scope is invalid', function (done) {
-    var app = bootstrap('foobar');
+	it('should not allow if scope is invalid', function (done) {
+		const app = bootstrap('foobar');
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(400, /invalid_scope/, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.expect(400, /invalid_scope/, done);
+	});
 
-  it('should allow if scope is valid', function (done) {
-    var app = bootstrap('my-scope');
+	it('should allow if scope is valid', function (done) {
+		const app = bootstrap('my-scope');
 
-    request(app)
-      .get('/?access_token=thom')
-      .expect(200, /nightworld/, done);
-  });
+		request(app)
+			.get('/?access_token=thom')
+			.expect(200, /nightworld/, done);
+	});
 
 });


### PR DESCRIPTION
I realized with integrating the oauth code into api-service, that I’d first need to get them on the same page for linting and testing packages. 

I did this in a few steps locally where each phase I validated the tests still all passed:
* Update non-test code to eslint standards
  * This included extra steps of moving var self = this for function usage into direct this usage with arrow functions
  * Adding use strict to those files ended up requiring one change in most of the tests where they were previously passing `true` as the response for `getClient` and previously doing something like client.clientSecret = 'thingy' would be fine if client was a bool, but no longer was with use strict. This was the only functional change made to my knowledge
* Update tests to eslint standards
* Update packages to match package versions from api-service

This will be merged and then we'll deprecate this repo as we migrate everything over to api-service